### PR TITLE
feat: handle exit codes according to validation results

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -15208,7 +15208,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.RequirementError = exports.parse = void 0;
+exports.CommitExpressiveMessage = exports.RequirementError = exports.parse = void 0;
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 /**
  * Error message with a caret pointing to the location of the error.
@@ -15247,6 +15247,7 @@ class CommitExpressiveMessage {
         return this.message;
     }
 }
+exports.CommitExpressiveMessage = CommitExpressiveMessage;
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
  */
@@ -15619,7 +15620,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const datasources_1 = __nccwpck_require__(1751);
-const conventional_commit_1 = __nccwpck_require__(2775);
+const validator_1 = __nccwpck_require__(4630);
 /**
  * Main entry point for the GitHub Action.
  */
@@ -15627,40 +15628,31 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info("📄 CommitMe - Conventional Commit compliance validation");
-            if (github.context.eventName !== "pull_request")
-                throw new Error("This action only works on pull requests.");
+            if (github.context.eventName !== "pull_request") {
+                core.setFailed("❌ This action only works on pull requests.");
+                return;
+            }
             // Setting up the environment
             const token = core.getInput("token");
             const octokit = github.getOctokit(token);
             const datasource = new datasources_1.GitHubSource(octokit);
-            // Gathering commit message information
             core.startGroup("🔎 Scanning Pull Request");
+            let errorCount = 0;
+            // Gathering commit message information
             const commits = yield datasource.getCommitMessages();
-            commits.forEach(commit => core.info(`📄 ${commit.hash}: ${commit.message.substring(0, 77)}${commit.message.length > 80 ? "..." : ""}`));
-            core.endGroup();
-            const errors = [];
-            try {
-                commits.forEach(commit => {
-                    try {
-                        (0, conventional_commit_1.parse)(commit);
-                        core.info(`✅ ${commit.hash}`);
-                    }
-                    catch (error) {
-                        core.startGroup(`❌ ${commit.hash}`);
-                        if (Array.isArray(error)) {
-                            error
-                                .filter(e => e instanceof conventional_commit_1.RequirementError)
-                                .forEach(e => {
-                                core.error(`❌ ${e.message}`);
-                                errors.push(e.message);
-                            });
-                        }
-                        core.endGroup();
-                    }
-                });
+            const results = (0, validator_1.validate)(commits);
+            // Outputting validation results
+            for (const commit of results) {
+                core.info(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.message.substring(0, 77)}${commit.commit.message.length > 80 ? "..." : ""}`);
+                commit.errors.forEach(error => core.error(error, { title: "Conventional Commit Compliance" }));
+                errorCount += commit.errors.length;
             }
-            catch (error) {
-                core.error(`${error}`);
+            core.endGroup();
+            if (errorCount === 0) {
+                core.info(`✅ All your commits are compliant with Conventional Commit.`);
+            }
+            else {
+                core.setFailed(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
             }
         }
         catch (ex) {
@@ -15669,6 +15661,77 @@ function run() {
     });
 }
 run();
+
+
+/***/ }),
+
+/***/ 4630:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.validate = void 0;
+const conventionalCommit = __importStar(__nccwpck_require__(2775));
+const conventional_commit_1 = __nccwpck_require__(2775);
+/**
+ * Validates the given set of commit messages against the conventional commit specification.
+ * @param commits The commits to validate
+ * @returns A list of validation results
+ * @see https://www.conventionalcommits.org/en/v1.0.0/
+ */
+const validate = (commits) => {
+    const validationResults = [];
+    for (const commit of commits) {
+        const result = {
+            commit: commit,
+            errors: [],
+        };
+        try {
+            conventionalCommit.parse(commit);
+        }
+        catch (error) {
+            if (Array.isArray(error)) {
+                error
+                    .filter(e => e instanceof conventionalCommit.RequirementError)
+                    .forEach(e => e.errors
+                    .filter(e => e instanceof conventional_commit_1.CommitExpressiveMessage)
+                    .forEach(e => result.errors.push(e.message)));
+            }
+        }
+        validationResults.push(result);
+    }
+    return validationResults;
+};
+exports.validate = validate;
 
 
 /***/ }),

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -13482,7 +13482,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.RequirementError = exports.parse = void 0;
+exports.CommitExpressiveMessage = exports.RequirementError = exports.parse = void 0;
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 /**
  * Error message with a caret pointing to the location of the error.
@@ -13521,6 +13521,7 @@ class CommitExpressiveMessage {
         return this.message;
     }
 }
+exports.CommitExpressiveMessage = CommitExpressiveMessage;
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
  */
@@ -13869,7 +13870,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const commander_1 = __nccwpck_require__(4379);
 const datasources_1 = __nccwpck_require__(1751);
-const conventional_commit_1 = __nccwpck_require__(2775);
+const validator_1 = __nccwpck_require__(4630);
 const program = new commander_1.Command();
 /**
  * Main entry point for the CLI tool.
@@ -13884,27 +13885,95 @@ program
     .action(() => __awaiter(void 0, void 0, void 0, function* () {
     console.log("📄 CommitMe - Conventional Commit compliance validation");
     console.log("-------------------------------------------------------");
-    const errors = [];
     const datasource = new datasources_1.GitSource();
-    try {
-        const commits = yield datasource.getCommitMessages();
-        commits.forEach(commit => {
-            try {
-                (0, conventional_commit_1.parse)(commit);
-            }
-            catch (error) {
-                if (Array.isArray(error)) {
-                    error.filter(e => e instanceof conventional_commit_1.RequirementError).forEach(e => errors.push(e.message));
-                }
-            }
-        });
+    const commits = yield datasource.getCommitMessages();
+    let errorCount = 0;
+    const results = (0, validator_1.validate)(commits);
+    for (const commit of results) {
+        console.log(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.message.substring(0, 77)}${commit.commit.message.length > 80 ? "..." : ""}`);
+        commit.errors.forEach(error => console.log(error));
+        errorCount += commit.errors.length;
     }
-    catch (error) {
-        console.log(error);
+    console.log("-------------------------------------------------------");
+    if (errorCount === 0) {
+        console.log(`✅ All your commits are compliant with Conventional Commit.`);
     }
-    console.log(errors.join("\n"));
+    else {
+        program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+    }
 }));
 program.parse(process.argv);
+
+
+/***/ }),
+
+/***/ 4630:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.validate = void 0;
+const conventionalCommit = __importStar(__nccwpck_require__(2775));
+const conventional_commit_1 = __nccwpck_require__(2775);
+/**
+ * Validates the given set of commit messages against the conventional commit specification.
+ * @param commits The commits to validate
+ * @returns A list of validation results
+ * @see https://www.conventionalcommits.org/en/v1.0.0/
+ */
+const validate = (commits) => {
+    const validationResults = [];
+    for (const commit of commits) {
+        const result = {
+            commit: commit,
+            errors: [],
+        };
+        try {
+            conventionalCommit.parse(commit);
+        }
+        catch (error) {
+            if (Array.isArray(error)) {
+                error
+                    .filter(e => e instanceof conventionalCommit.RequirementError)
+                    .forEach(e => e.errors
+                    .filter(e => e instanceof conventional_commit_1.CommitExpressiveMessage)
+                    .forEach(e => result.errors.push(e.message)));
+            }
+        }
+        validationResults.push(result);
+    }
+    return validationResults;
+};
+exports.validate = validate;
 
 
 /***/ }),

--- a/src/conventional_commit.ts
+++ b/src/conventional_commit.ts
@@ -369,4 +369,4 @@ const parse = (commit: datasources.ICommit): IConventionalCommit => {
 
 const rules: IRequirements[] = [new Requirement1(), new Requirement4(), new Requirement5()];
 
-export { parse, RequirementError };
+export { parse, RequirementError, CommitExpressiveMessage };

--- a/src/entrypoints/cli.ts
+++ b/src/entrypoints/cli.ts
@@ -8,7 +8,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import { Command } from "commander";
 import { GitSource } from "../datasources";
-import { RequirementError, parse } from "../conventional_commit";
+import { validate } from "../validator";
 
 const program = new Command();
 
@@ -27,25 +27,28 @@ program
     console.log("📄 CommitMe - Conventional Commit compliance validation");
     console.log("-------------------------------------------------------");
 
-    const errors: string[] = [];
     const datasource = new GitSource();
+    const commits = await datasource.getCommitMessages();
 
-    try {
-      const commits = await datasource.getCommitMessages();
-      commits.forEach(commit => {
-        try {
-          parse(commit);
-        } catch (error) {
-          if (Array.isArray(error)) {
-            error.filter(e => e instanceof RequirementError).forEach(e => errors.push(e.message));
-          }
-        }
-      });
-    } catch (error) {
-      console.log(error);
+    let errorCount = 0;
+    const results = validate(commits);
+
+    for (const commit of results) {
+      console.log(
+        `${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.message.substring(0, 77)}${
+          commit.commit.message.length > 80 ? "..." : ""
+        }`
+      );
+      commit.errors.forEach(error => console.log(error));
+      errorCount += commit.errors.length;
     }
 
-    console.log(errors.join("\n"));
+    console.log("-------------------------------------------------------");
+    if (errorCount === 0) {
+      console.log(`✅ All your commits are compliant with Conventional Commit.`);
+    } else {
+      program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+    }
   });
 
 program.parse(process.argv);

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,0 +1,55 @@
+/* 
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+import * as datasources from "./datasources";
+import * as conventionalCommit from "./conventional_commit";
+import { CommitExpressiveMessage } from "./conventional_commit";
+
+/**
+ * Validation result interface
+ * @interface IValidationResult
+ * @member commit The commit that was validated
+ * @member errors List of error messages
+ */
+interface IValidationResult {
+  commit: datasources.ICommit;
+  errors: string[];
+}
+
+/**
+ * Validates the given set of commit messages against the conventional commit specification.
+ * @param commits The commits to validate
+ * @returns A list of validation results
+ * @see https://www.conventionalcommits.org/en/v1.0.0/
+ */
+const validate = (commits: datasources.ICommit[]): IValidationResult[] => {
+  const validationResults: IValidationResult[] = [];
+  for (const commit of commits) {
+    const result: IValidationResult = {
+      commit: commit,
+      errors: [],
+    };
+
+    try {
+      conventionalCommit.parse(commit);
+    } catch (error) {
+      if (Array.isArray(error)) {
+        error
+          .filter(e => e instanceof conventionalCommit.RequirementError)
+          .forEach(e =>
+            (e as conventionalCommit.RequirementError).errors
+              .filter(e => e instanceof CommitExpressiveMessage)
+              .forEach(e => result.errors.push(e.message))
+          );
+      }
+    }
+
+    validationResults.push(result);
+  }
+  return validationResults;
+};
+
+export { validate };


### PR DESCRIPTION
The following behavior is added:
- CLI: returns non-zero in case _at least_ 1 validation error has been found
- GHA: fails the execution in case _at least_ 1 validation error has been found