### PR TITLE
fix: use github context to reduce minimum permissions required

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,19 +12,25 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}  # Ensure that only one instance of this workflow is running per Pull Request
+  cancel-in-progress: true  # Cancel any previous runs of this workflow
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read  # Required to retrieve the commits associated with your Pull Request
+  pull-requests: write  # Required to add a label to your Pull Request
 
 jobs:
-  commit-message:
+  commit-me:
     name: Conventional Commits Compliance
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-
       - name: Run CommitMe
         uses: ./
         with:
-          token: ${{ github.token }}
+          token: ${{ github.token }}  # Required to retrieve the commits associated with
+                                      # your Pull Request
+          include-commits: true  # Forces the inclusion of commits associated with your
+                                 # Pull Request without requiring the `contents:write`
+                                 # permission

--- a/README.md
+++ b/README.md
@@ -62,20 +62,23 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}  # Ensure that only one instance of this workflow is running per Pull Request
+  cancel-in-progress: true  # Cancel any previous runs of this workflow
+
 permissions:
-  contents: write  # OPTIONAL; needed to determine merge strategies
-  pull-request: write  # OPTIONAL; needed to manage labels
+  contents: read  # NOTE; you will need to change this permission to `write` in case you do not provide the `include-commits` input parameter.
+  pull-requests: write  # OPTIONAL; only required when you want CommitMe to update labels in your Pull Request, set `update-labels` to `false` if you do not require this feature.
 
 jobs:
   commit-me:
-    name: Conventional Commit compliance
+    name: Conventional Commits Compliance
     runs-on: ubuntu-latest
     steps:
       - uses: dev-build-deploy/commit-me@v0
         with:
-          token: ${{ github.token }}
-          update-labels: true  # OPTIONAL; manages labels on your Pull Request, defaults to `true`
-          include-commits: true  # OPTIONAL; includes commits associated with your Pull Request
+          token: ${{ github.token }}  # Required to retrieve the commits associated with your Pull Request
+          include-commits: true  # OPTIONAL; forces the inclusion of commits associated with your Pull Request
 ```
 
 This will result in output similar to:

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ branding:
 inputs:
   token: 
     description: 'GitHub token used to access GitHub (eg. github.token)'
-    required: true
+    required: false
   
   update-labels:
     description: 'Update labels on Pull Request (`breaking`, `feature` or `fix`)'

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -22,9 +22,9 @@ Selection of the strategy is based on either:
 
 ## Workflows
 
-### Pull Request scanning
+### Pull Request and associated commit scanning
 
-You can scan the commits in your pull request for compliance with the [Conventional Commits] specification.
+In order to scan your pull request, including associated commits, for compliance with the [Conventional Commits] specification;
 
 ```yaml
 name: Conventional Commits
@@ -35,27 +35,61 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}  # Ensure that only one instance of this workflow is running per Pull Request
+  cancel-in-progress: true  # Cancel any previous runs of this workflow
+
 permissions:
-  contents: write
-  pull-request: write
+  contents: read  # NOTE; you will need to change this permission to `write` in case you do not provide the `include-commits` input parameter.
+  pull-requests: write  # OPTIONAL; only required when you want CommitMe to update labels in your Pull Request, set `update-labels` to `false` if you do not require this feature.
 
 jobs:
   commit-me:
-    name: Conventional Commit compliance
+    name: Conventional Commits Compliance
     runs-on: ubuntu-latest
     steps:
       - uses: dev-build-deploy/commit-me@v0
         with:
-          token: ${{ github.token }}
-          update-labels: true  # OPTIONAL; manages labels on your Pull Request, defaults to `true`
+          token: ${{ github.token }}  # Required to retrieve the commits associated with your Pull Request
+          include-commits: true  # OPTIONAL; forces the inclusion of commits associated with your Pull Request
 ```
+
+### Pull Request scanning (w/o Pull Request labels)
+
+You can also opt for limiting the validation to your Pull Request only. This option is preferred when you do **NOT** have rebase merges enabled;
+
+```yaml
+name: Conventional Commits
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}  # Ensure that only one instance of this workflow is running per Pull Request
+  cancel-in-progress: true  # Cancel any previous runs of this workflow
+
+permissions:
+  contents: read  # NOTE; you will need to change this permission to `write` in case you do not provide the `include-commits` input parameter.
+
+jobs:
+  commit-me:
+    name: Conventional Commits Compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dev-build-deploy/commit-me@v0
+        with:
+          update-labels: false  # OPTIONAL; do not update the Pull Request labels based on the Conventional Commits information.
+          include-commits: false  # OPTIONAL; enforces the exclusion of commits associated with your Pull Request
+```
+
+In addition, above example has disabled pull request label management, just to show 
 
 ### Event triggers & activities
 
-There are two main triggers relevant for validate your Pull Requests:
-
-* [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request): use this trigger when you allow Pull Requests created from branches directly on the repository itself.
-* [`pull_request_target`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target): will be triggered in case a Pull Request is opened from a fork, targetting your repository.
+We recommend using the [`pull_request`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) trigger for running this GitHub Action.
 
 In addition, we recommend the following activity types: 
 | Activity | Description |
@@ -64,13 +98,15 @@ In addition, we recommend the following activity types:
 | `edited` | Validates any change to the Pull Requests title |
 | `synchronize` | Validate all subsequent commits added to the (open) Pull Request. This is only required in case rebase merges are enabled on the target repository. |
 
+> **NOTE**: Although supported, the trigger `pull_request_target` has elevated permissions to access secrets and your repository. Please refer to this [GitHub security blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for more details 
+
 ### Inputs
 
 | Name | Required | Description |
 | --- | --- | --- |
-| `token` | *YES* | GitHub token needed to access your commits in your pull request |
-| `update-labels` | *NO* | Allow CommitMe to manage [labels](#pull-request-labels) based on the [Conventional Commits] metadata, required `write` permissions for `pull-request`, defaults to `true` |
-| `include-commits` | *NO* | Include commits associated with the Pull Request; by default we use the repository configuration settings to determine this value. |
+| `token` | *NO* | GitHub token needed to access your commits in your pull request. This is **only** required in case you want to:<br><ul><li>Validate commits associated with your Pull Request</li><li>Update labels in your Pull Request</li></ul> |
+| `update-labels` | *NO* | Allow CommitMe to manage [labels](#pull-request-labels) based on the [Conventional Commits] metadata (requires `write` permissions for `pull-requests`), defaults to `true` |
+| `include-commits` | *NO* | Include commits associated with the Pull Request; by default we use the repository configuration settings to determine this value (requires `write` permissions for `contents`). |
 
 ### Permissions
 
@@ -78,7 +114,7 @@ In addition, we recommend the following activity types:
 | --- | --- | --- |
 | `pull-request` | `read` | Access to read pull request data, including associated commits |
 | `pull-request` | `write` | Only required when the `update-labels`-input is set to `true`, allows for updating labels associated with the [Conventional Commits] in your Pull Request |
-| `contents` | `write` | This permission is required in order to determine whether this repository allows rebase merges (see: [validation strategies](#validation-strategies))<br><br>If you do not want to provide this permission, you can also use the `include-commits` [input parameter](#inputs) to bypass the automatic checl. |
+| `contents` | `write` | This permission is required in order to determine whether this repository allows rebase merges (see: [validation strategies](#validation-strategies))<br><br>If you do not want to provide this permission, you can also use the `include-commits` [input parameter](#inputs) to bypass the automatic check. |
 
 ## Pull Request Labels
 

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -15381,23 +15381,6 @@ exports.GitSource = GitSource;
  * GitHub data source for determining which commits need to be validated.
  */
 class GitHubSource {
-    constructor(prTitleOnly) {
-        this.prTitleOnly = prTitleOnly;
-    }
-    getPullRequest() {
-        var _a, _b;
-        return __awaiter(this, void 0, void 0, function* () {
-            const octokit = github.getOctokit(core.getInput("token"));
-            const pullRequestNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
-            (0, assert_1.default)(pullRequestNumber);
-            const { data: pullRequest } = yield octokit.rest.pulls.get(Object.assign(Object.assign({}, github.context.repo), { pull_number: pullRequestNumber }));
-            return {
-                hash: `#${pullRequest.number}`,
-                message: pullRequest.title,
-                body: (_b = pullRequest.body) !== null && _b !== void 0 ? _b : "", // TODO: Validate pull request body
-            };
-        });
-    }
     getCommitMessages() {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
@@ -15405,16 +15388,13 @@ class GitHubSource {
             const pullRequestNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
             (0, assert_1.default)(pullRequestNumber);
             const commits = yield octokit.rest.pulls.listCommits(Object.assign(Object.assign({}, github.context.repo), { pull_number: pullRequestNumber }));
-            const result = this.prTitleOnly
-                ? []
-                : commits.data.map((commit) => {
-                    return {
-                        hash: commit.sha,
-                        message: commit.commit.message.split("\n")[0],
-                        body: "", // TODO: Validate commit body
-                    };
-                });
-            return result;
+            return commits.data.map((commit) => {
+                return {
+                    hash: commit.sha,
+                    message: commit.commit.message.split("\n")[0],
+                    body: "", // TODO: Validate commit body
+                };
+            });
         });
     }
 }
@@ -15465,6 +15445,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
@@ -15472,6 +15455,7 @@ const repository = __importStar(__nccwpck_require__(259));
 const datasources_1 = __nccwpck_require__(1751);
 const validator_1 = __nccwpck_require__(4630);
 const github_1 = __nccwpck_require__(978);
+const assert_1 = __importDefault(__nccwpck_require__(9491));
 /**
  * Determines the label to be applied to the pull request.
  * @param commits The validated commits to determine the label from
@@ -15508,30 +15492,42 @@ const reportErrorMessages = (results) => {
  * Main entry point for the GitHub Action.
  */
 function run() {
+    var _a, _b;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info("📄 CommitMe - Conventional Commit compliance validation");
             core.startGroup("📝 Checking repository configuration");
+            const githubToken = (_a = core.getInput("token")) !== null && _a !== void 0 ? _a : undefined;
             if (!["pull_request", "pull_request_target"].includes(github.context.eventName)) {
                 core.setFailed("❌ This action only works on pull requests.");
                 return;
             }
+            (0, assert_1.default)(github.context.payload.pull_request);
+            (0, assert_1.default)(github.context.payload.pull_request.base.repo);
             let pullrequestOnly = core.getInput("include-commits") ? core.getBooleanInput("include-commits") : undefined;
             if (pullrequestOnly === undefined) {
-                yield repository.checkConfiguration();
-                pullrequestOnly = yield repository.hasRebaseMerge();
+                repository.checkConfiguration(github.context.payload.pull_request.base.repo);
+                pullrequestOnly = github.context.payload.pull_request.base.repo.base.allow_rebase_merge === false;
             }
             else {
                 core.info(pullrequestOnly === false
                     ? "ℹ️ Validating both Pull Request title and all associated commits."
                     : "ℹ️ Only validating the Pull Request title.");
             }
+            if (githubToken === undefined && pullrequestOnly === false) {
+                core.setFailed("❌ The token input is required when validating commits.");
+                return;
+            }
             // Setting up the environment
-            const datasource = new datasources_1.GitHubSource(!pullrequestOnly);
+            const datasource = new datasources_1.GitHubSource();
             const commits = yield datasource.getCommitMessages();
             core.endGroup();
             // Gathering commit message information
-            const pullrequest = yield datasource.getPullRequest();
+            const pullrequest = {
+                hash: `#${github.context.payload.pull_request.number}`,
+                message: github.context.payload.pull_request.title,
+                body: (_b = github.context.payload.pull_request.body) !== null && _b !== void 0 ? _b : "",
+            };
             const resultCommits = pullrequestOnly ? (0, validator_1.validateCommits)(commits) : [];
             const resultPullrequest = (0, validator_1.validatePullRequest)(pullrequest, resultCommits
                 .map(commit => commit.conventionalCommit)
@@ -15549,7 +15545,10 @@ function run() {
                 return;
             }
             // Updating the pull request label
-            if (core.getBooleanInput("update-labels") === true) {
+            if (githubToken === undefined) {
+                core.warning("⚠️ The token input is required to update the pull request label.");
+            }
+            else if (core.getBooleanInput("update-labels") === true) {
                 const label = yield determineLabel([resultPullrequest, ...resultCommits]);
                 if (label !== undefined)
                     yield (0, github_1.updatePullRequestLabels)(label);
@@ -15609,7 +15608,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.updatePullRequestLabels = exports.getRepository = void 0;
+exports.updatePullRequestLabels = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 /**
@@ -15632,16 +15631,6 @@ const updatePullRequestLabels = (label) => __awaiter(void 0, void 0, void 0, fun
     }
 });
 exports.updatePullRequestLabels = updatePullRequestLabels;
-/**
- * Retrieves repository metadata.
- * @returns Repository metadata
- */
-const getRepository = () => __awaiter(void 0, void 0, void 0, function* () {
-    const octokit = github.getOctokit(core.getInput("token"));
-    const { data: repository } = yield octokit.rest.repos.get(Object.assign({}, github.context.repo));
-    return repository;
-});
-exports.getRepository = getRepository;
 
 
 /***/ }),
@@ -15733,18 +15722,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.hasRebaseMerge = exports.checkConfiguration = void 0;
-const github_1 = __nccwpck_require__(978);
+exports.checkConfiguration = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 /**
  * Checks the repository merge configuration;
@@ -15752,8 +15731,7 @@ const core = __importStar(__nccwpck_require__(2186));
  * - Whether squash commits are enabled and whether the default subject is based on the Pull Request title
  * - Whether rebase commits are enabled
  */
-const checkConfiguration = () => __awaiter(void 0, void 0, void 0, function* () {
-    const repository = yield (0, github_1.getRepository)();
+const checkConfiguration = (repository) => {
     if (repository.allow_merge_commit === undefined ||
         repository.allow_squash_merge === undefined ||
         repository.allow_rebase_merge === undefined) {
@@ -15780,16 +15758,8 @@ const checkConfiguration = () => __awaiter(void 0, void 0, void 0, function* () 
     core.info(repository.allow_rebase_merge === true
         ? "ℹ️ Rebase merges are enabled, validating both Pull Request title and all associated commits."
         : "ℹ️ Rebase merges are disabled, only validating the Pull Request title.");
-});
+};
 exports.checkConfiguration = checkConfiguration;
-/**
- * Checks whether rebase merges are enabled.
- * @returns Whether rebase merges are enabled.
- */
-const hasRebaseMerge = () => __awaiter(void 0, void 0, void 0, function* () {
-    return (yield (0, github_1.getRepository)()).allow_rebase_merge === true;
-});
-exports.hasRebaseMerge = hasRebaseMerge;
 
 
 /***/ }),

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -15503,8 +15503,11 @@ function run() {
                 return;
             }
             (0, assert_1.default)(github.context.payload.pull_request);
-            (0, assert_1.default)(github.context.payload.pull_request.base.repo);
-            let pullrequestOnly = core.getInput("include-commits") ? core.getBooleanInput("include-commits") : undefined;
+            let pullrequestOnly = core.getInput("include-commits") ? !core.getBooleanInput("include-commits") : undefined;
+            if (githubToken === undefined && pullrequestOnly !== true) {
+                core.setFailed("❌ The `token` input is required for the current configuration of CommitMe.");
+                return;
+            }
             if (pullrequestOnly === undefined) {
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
                 pullrequestOnly = github.context.payload.pull_request.base.repo.base.allow_rebase_merge === false;
@@ -15514,13 +15517,9 @@ function run() {
                     ? "ℹ️ Validating both Pull Request title and all associated commits."
                     : "ℹ️ Only validating the Pull Request title.");
             }
-            if (githubToken === undefined && pullrequestOnly === false) {
-                core.setFailed("❌ The token input is required when validating commits.");
-                return;
-            }
             // Setting up the environment
             const datasource = new datasources_1.GitHubSource();
-            const commits = yield datasource.getCommitMessages();
+            const commits = pullrequestOnly ? [] : yield datasource.getCommitMessages();
             core.endGroup();
             // Gathering commit message information
             const pullrequest = {
@@ -15528,14 +15527,14 @@ function run() {
                 message: github.context.payload.pull_request.title,
                 body: (_b = github.context.payload.pull_request.body) !== null && _b !== void 0 ? _b : "",
             };
-            const resultCommits = pullrequestOnly ? (0, validator_1.validateCommits)(commits) : [];
+            const resultCommits = (0, validator_1.validateCommits)(commits);
             const resultPullrequest = (0, validator_1.validatePullRequest)(pullrequest, resultCommits
                 .map(commit => commit.conventionalCommit)
                 .filter(commit => commit !== undefined));
             core.startGroup(`🔎 Scanning Pull Request`);
             let errorCount = reportErrorMessages([resultPullrequest]);
             core.endGroup();
-            if (pullrequestOnly) {
+            if (!pullrequestOnly) {
                 core.startGroup("🔎 Scanning Commits associated with Pull Request");
                 errorCount += reportErrorMessages(resultCommits);
                 core.endGroup();

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -15382,23 +15382,6 @@ exports.GitSource = GitSource;
  * GitHub data source for determining which commits need to be validated.
  */
 class GitHubSource {
-    constructor(prTitleOnly) {
-        this.prTitleOnly = prTitleOnly;
-    }
-    getPullRequest() {
-        var _a, _b;
-        return __awaiter(this, void 0, void 0, function* () {
-            const octokit = github.getOctokit(core.getInput("token"));
-            const pullRequestNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
-            (0, assert_1.default)(pullRequestNumber);
-            const { data: pullRequest } = yield octokit.rest.pulls.get(Object.assign(Object.assign({}, github.context.repo), { pull_number: pullRequestNumber }));
-            return {
-                hash: `#${pullRequest.number}`,
-                message: pullRequest.title,
-                body: (_b = pullRequest.body) !== null && _b !== void 0 ? _b : "", // TODO: Validate pull request body
-            };
-        });
-    }
     getCommitMessages() {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
@@ -15406,16 +15389,13 @@ class GitHubSource {
             const pullRequestNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
             (0, assert_1.default)(pullRequestNumber);
             const commits = yield octokit.rest.pulls.listCommits(Object.assign(Object.assign({}, github.context.repo), { pull_number: pullRequestNumber }));
-            const result = this.prTitleOnly
-                ? []
-                : commits.data.map((commit) => {
-                    return {
-                        hash: commit.sha,
-                        message: commit.commit.message.split("\n")[0],
-                        body: "", // TODO: Validate commit body
-                    };
-                });
-            return result;
+            return commits.data.map((commit) => {
+                return {
+                    hash: commit.sha,
+                    message: commit.commit.message.split("\n")[0],
+                    body: "", // TODO: Validate commit body
+                };
+            });
         });
     }
 }

--- a/src/datasources.ts
+++ b/src/datasources.ts
@@ -48,28 +48,6 @@ class GitSource implements IDataSource {
  * GitHub data source for determining which commits need to be validated.
  */
 class GitHubSource implements IDataSource {
-  prTitleOnly: boolean;
-
-  constructor(prTitleOnly: boolean) {
-    this.prTitleOnly = prTitleOnly;
-  }
-
-  public async getPullRequest(): Promise<ICommit> {
-    const octokit = github.getOctokit(core.getInput("token"));
-    const pullRequestNumber = github.context.payload.pull_request?.number;
-    assert(pullRequestNumber);
-
-    const { data: pullRequest } = await octokit.rest.pulls.get({
-      ...github.context.repo,
-      pull_number: pullRequestNumber,
-    });
-    return {
-      hash: `#${pullRequest.number}`,
-      message: pullRequest.title,
-      body: pullRequest.body ?? "", // TODO: Validate pull request body
-    };
-  }
-
   public async getCommitMessages(): Promise<ICommit[]> {
     const octokit = github.getOctokit(core.getInput("token"));
     const pullRequestNumber = github.context.payload.pull_request?.number;
@@ -80,17 +58,13 @@ class GitHubSource implements IDataSource {
       pull_number: pullRequestNumber,
     });
 
-    const result = this.prTitleOnly
-      ? []
-      : commits.data.map((commit: any) => {
-          return {
-            hash: commit.sha,
-            message: commit.commit.message.split("\n")[0],
-            body: "", // TODO: Validate commit body
-          };
-        });
-
-    return result;
+    return commits.data.map((commit: any) => {
+      return {
+        hash: commit.sha,
+        message: commit.commit.message.split("\n")[0],
+        body: "", // TODO: Validate commit body
+      };
+    });
   }
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -33,16 +33,4 @@ const updatePullRequestLabels = async (label: "fix" | "feature" | "breaking") =>
   }
 };
 
-/**
- * Retrieves repository metadata.
- * @returns Repository metadata
- */
-const getRepository = async () => {
-  const octokit = github.getOctokit(core.getInput("token"));
-  const { data: repository } = await octokit.rest.repos.get({
-    ...github.context.repo,
-  });
-  return repository;
-};
-
-export { getRepository, updatePullRequestLabels };
+export { updatePullRequestLabels };

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,7 +4,6 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: GPL-3.0-or-later
 */
 
-import { getRepository } from "./github";
 import * as core from "@actions/core";
 
 /**
@@ -13,9 +12,7 @@ import * as core from "@actions/core";
  * - Whether squash commits are enabled and whether the default subject is based on the Pull Request title
  * - Whether rebase commits are enabled
  */
-const checkConfiguration = async () => {
-  const repository = await getRepository();
-
+const checkConfiguration = (repository: any) => {
   if (
     repository.allow_merge_commit === undefined ||
     repository.allow_squash_merge === undefined ||
@@ -54,12 +51,4 @@ const checkConfiguration = async () => {
   );
 };
 
-/**
- * Checks whether rebase merges are enabled.
- * @returns Whether rebase merges are enabled.
- */
-const hasRebaseMerge = async (): Promise<boolean> => {
-  return (await getRepository()).allow_rebase_merge === true;
-};
-
-export { checkConfiguration, hasRebaseMerge };
+export { checkConfiguration };


### PR DESCRIPTION
This commit removes the need to retrieve Pull Request information using
your GitHub token. This will allow you to configure CommitMe to use
the least amount of permissions required to operate (`contents: read`).