### PR TITLE
feat(core): add support for scope and type checking

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -34,3 +34,19 @@ jobs:
           include-commits: true  # Forces the inclusion of commits associated with your
                                  # Pull Request without requiring the `contents:write`
                                  # permission
+          scopes: |  # Limit the Conventional Commits scope to the following values;
+            action
+            cli
+            core
+          types: |  # Limit the Conventional Commits type to the following values;
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test

--- a/README.md
+++ b/README.md
@@ -13,15 +13,44 @@ CommitMe provides multiple tools for validating commit messages against [Convent
   * Managing [labels](./docs/github-action.md#pull-request-labels) in your Pull Request
   * Two [validation strategies](./docs/github-action.md#validation-strategies) (Pull Request title only, Pull Request title _and_ associated commits) based on your repositories merge options
 
+
+![Example](./docs/images/cli_example.png)
+
 Both use the same [output format](#output-format) for expressing non-compliance issues.
 
 ## Specification
 
-In addition to the [Conventional Commits] specification, an [extended Pull Request specification](./docs/specifications.md#extended-pull-request-specification) is added to ensure best-in-class integration with the [GitHub Action](./docs/github-action.md).
+In addition to the [Conventional Commits] specification, extensions are added for [Conventional Commit messages](./docs/specifications.md#extended-conventional-commits-specification) and [Pull Requests](./docs/specifications.md#extended-pull-request-specification), providing additional rules such as:
+
+- Limit the `type` and `scope` to a preconfigured list of items.
+- Ensure that the Pull Request title is using a `type` correlating with its associated commits.
 
 _Please refer to the [dedicated documentation](./docs/specifications.md) for more details._
 
-## Tools
+## Output format
+
+CommitMe is using an output format derived from LLVM's [expressive diagnostics formatting](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#expressive-diagnostic-formatting);
+
+```
+2d9f21c2e2bb0f61ff88a99e5c0cb8d5771313c7:1:0: error: Commits MUST be prefixed with[...]
+^                                        ^ ^         ^
+|                                        | |         |
+|                                        | |         `-- Conventional Commits requirement
+|                                        | `-- Column bumber
+|                                        `-- Line number
+`-- Commit SHA                                   
+```
+
+> **NOTE**: The Conventional Commits requirement is truncated in the above example
+
+| Item | Description |
+| --- | --- |
+| `Commit SHA` | The commit hash of the commit containing non compliance issue |
+| `Line number` | Which line in the commit message contains the issue (**NOTE**: line 1 indicates the subject) |
+| `Column number` | Starting index of the non compliance issue |
+| `Conventional Commits requirement` | Full description taken from the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification), with highlights indicating which parts are non-compliant |
+
+## Basic Usage
 
 ### Command Line Interface
 
@@ -90,29 +119,6 @@ In addition;
 * A [label](./docs/github-action.md#pull-request-labels) (`breaking`, `feature` or `fix`) is added to your Pull Request.
 
 _You can find more details in the [dedicated documentation](./docs/github-action.md)_
-
-## Output format
-
-CommitMe is using an output format derived from LLVM's [expressive diagnostics formatting](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#expressive-diagnostic-formatting);
-
-```
-2d9f21c2e2bb0f61ff88a99e5c0cb8d5771313c7:1:0: error: Commits MUST be prefixed with[...]
-^                                        ^ ^         ^
-|                                        | |         |
-|                                        | |         `-- Conventional Commits requirement
-|                                        | `-- Column bumber
-|                                        `-- Line number
-`-- Commit SHA                                   
-```
-
-> **NOTE**: The Conventional Commits requirement is truncated in the above example
-
-| Item | Description |
-| --- | --- |
-| `Commit SHA` | The commit hash of the commit containing non compliance issue |
-| `Line number` | Which line in the commit message contains the issue (**NOTE**: line 1 indicates the subject) |
-| `Column number` | Starting index of the non compliance issue |
-| `Conventional Commits requirement` | Full description taken from the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification), with highlights indicating which parts are non-compliant |
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,14 @@ inputs:
   include-commits:
     description: 'Include commits associated with the Pull Request; by default we use the repository configuration settings to determine this value.'
     required: false
+  
+  scopes:
+    description: 'Conventional Commits scopes allowed for this repository; be default we accept all scopes.'
+    required: false
+  
+  types:
+    description: 'Conventional Commits types allowed for this repository; by default we accept all types.'
+    required: false
 
 runs:
   using: 'node16'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,8 @@ Checks whether your commit messagesare compliant with the Conventional Commit sp
 
 Options:
   -b, --base-branch <branch>  The base branch to compare the current branch with.
+  -s, --scopes [scopes...]    Conventional Commits scopes to validate against.
+  -t, --types [types...]      Conventional Commits types to validate against.
   -h, --help                  display help for command
 ```
 

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -15194,6 +15194,43 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 5778:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
+/**
+ * Configuration class
+ * @class Configuration
+ * @member includeCommits Include commits in the validation process
+ * @member includePullRequest Include pull requests in the validation process
+ * @member scopes List of scopes to validate against
+ * @member types List of types to validate against
+ */
+class Configuration {
+    constructor() {
+        this.includeCommits = false;
+        this.includePullRequest = false;
+    }
+    static getInstance() {
+        if (!Configuration._instance) {
+            Configuration._instance = new Configuration();
+        }
+        return Configuration._instance;
+    }
+}
+exports.Configuration = Configuration;
+
+
+/***/ }),
+
 /***/ 2775:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -15456,6 +15493,7 @@ const datasources_1 = __nccwpck_require__(1751);
 const validator_1 = __nccwpck_require__(4630);
 const github_1 = __nccwpck_require__(978);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
+const configuration_1 = __nccwpck_require__(5778);
 /**
  * Determines the label to be applied to the pull request.
  * @param commits The validated commits to determine the label from
@@ -15488,6 +15526,19 @@ const reportErrorMessages = (results) => {
     }
     return errorCount;
 };
+const setConfiguration = () => {
+    var _a, _b;
+    (0, assert_1.default)(github.context.payload.pull_request);
+    const pullrequestOnly = core.getInput("include-commits")
+        ? !core.getBooleanInput("include-commits")
+        : github.context.payload.pull_request.base.repo.base.allow_rebase_merge === false;
+    // Set the global configuration
+    const config = configuration_1.Configuration.getInstance();
+    config.includeCommits = !pullrequestOnly;
+    config.includePullRequest = true;
+    config.scopes = (_a = core.getMultilineInput("scopes")) !== null && _a !== void 0 ? _a : [];
+    config.types = (_b = core.getMultilineInput("types")) !== null && _b !== void 0 ? _b : [];
+};
 /**
  * Main entry point for the GitHub Action.
  */
@@ -15496,45 +15547,49 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info("📄 CommitMe - Conventional Commit compliance validation");
+            setConfiguration();
             core.startGroup("📝 Checking repository configuration");
+            const datasource = new datasources_1.GitHubSource();
+            const config = configuration_1.Configuration.getInstance();
             const githubToken = (_a = core.getInput("token")) !== null && _a !== void 0 ? _a : undefined;
+            (0, assert_1.default)(github.context.payload.pull_request);
             if (!["pull_request", "pull_request_target"].includes(github.context.eventName)) {
                 core.setFailed("❌ This action only works on pull requests.");
                 return;
             }
-            (0, assert_1.default)(github.context.payload.pull_request);
-            let pullrequestOnly = core.getInput("include-commits") ? !core.getBooleanInput("include-commits") : undefined;
-            if (githubToken === undefined && pullrequestOnly !== true) {
+            if (githubToken === undefined && config.includeCommits === true) {
                 core.setFailed("❌ The `token` input is required for the current configuration of CommitMe.");
                 return;
             }
-            if (pullrequestOnly === undefined) {
+            if (core.getInput("include-commits") === undefined) {
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
-                pullrequestOnly = github.context.payload.pull_request.base.repo.base.allow_rebase_merge === false;
             }
             else {
-                core.info(pullrequestOnly === false
+                core.info(config.includeCommits === true
                     ? "ℹ️ Validating both Pull Request title and all associated commits."
                     : "ℹ️ Only validating the Pull Request title.");
             }
             // Setting up the environment
-            const datasource = new datasources_1.GitHubSource();
-            const commits = pullrequestOnly ? [] : yield datasource.getCommitMessages();
+            const commits = config.includeCommits ? yield datasource.getCommitMessages() : [];
             core.endGroup();
             // Gathering commit message information
-            const pullrequest = {
-                hash: `#${github.context.payload.pull_request.number}`,
-                message: github.context.payload.pull_request.title,
-                body: (_b = github.context.payload.pull_request.body) !== null && _b !== void 0 ? _b : "",
-            };
             const resultCommits = (0, validator_1.validateCommits)(commits);
-            const resultPullrequest = (0, validator_1.validatePullRequest)(pullrequest, resultCommits
-                .map(commit => commit.conventionalCommit)
-                .filter(commit => commit !== undefined));
-            core.startGroup(`🔎 Scanning Pull Request`);
-            let errorCount = reportErrorMessages([resultPullrequest]);
-            core.endGroup();
-            if (!pullrequestOnly) {
+            let errorCount = 0;
+            const allResults = [...resultCommits];
+            if (config.includePullRequest === true) {
+                core.startGroup(`🔎 Scanning Pull Request`);
+                const resultPullrequest = (0, validator_1.validatePullRequest)({
+                    hash: `#${github.context.payload.pull_request.number}`,
+                    message: github.context.payload.pull_request.title,
+                    body: (_b = github.context.payload.pull_request.body) !== null && _b !== void 0 ? _b : "",
+                }, resultCommits
+                    .map(commit => commit.conventionalCommit)
+                    .filter(commit => commit !== undefined));
+                allResults.push(resultPullrequest);
+                errorCount += reportErrorMessages([resultPullrequest]);
+                core.endGroup();
+            }
+            if (config.includeCommits === true) {
                 core.startGroup("🔎 Scanning Commits associated with Pull Request");
                 errorCount += reportErrorMessages(resultCommits);
                 core.endGroup();
@@ -15548,7 +15603,7 @@ function run() {
                 core.warning("⚠️ The token input is required to update the pull request label.");
             }
             else if (core.getBooleanInput("update-labels") === true) {
-                const label = yield determineLabel([resultPullrequest, ...resultCommits]);
+                const label = yield determineLabel(allResults);
                 if (label !== undefined)
                     yield (0, github_1.updatePullRequestLabels)(label);
             }
@@ -15776,6 +15831,7 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RequirementError = exports.pullRequestRules = exports.commitRules = void 0;
+const configuration_1 = __nccwpck_require__(5778);
 const logging_1 = __nccwpck_require__(1517);
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
@@ -15906,6 +15962,48 @@ class CC05 {
     }
 }
 /**
+ * The scope is REQUIRED and the value MUST be one of the configured values (...)
+ */
+class EC01 {
+    constructor() {
+        this.id = "EC-01";
+        this.description = "The scope is REQUIRED and the value MUST be one of the configured values (...)";
+    }
+    validate(commit) {
+        var _a, _b;
+        const config = configuration_1.Configuration.getInstance();
+        this.description = `The scope is REQUIRED and the value MUST be one of the configured values (${(_a = config === null || config === void 0 ? void 0 : config.scopes) === null || _a === void 0 ? void 0 : _a.join(", ")}).`;
+        if (config.scopes === undefined || ((_b = config.scopes) === null || _b === void 0 ? void 0 : _b.length) === 0)
+            return;
+        if (commit.scope.value !== undefined && config.scopes.includes(commit.scope.value.replace(/[()]+/g, "")))
+            return;
+        const error = new RequirementError(this, commit);
+        error.addError(["scope is REQUIRED", "and", "MUST be one of the configured values"], "scope");
+        throw error;
+    }
+}
+/**
+ * The type MUST be one of the configured values (...)
+ */
+class EC02 {
+    constructor() {
+        this.id = "EC-02";
+        this.description = "The type MUST be one of the configured values (...)";
+    }
+    validate(commit) {
+        var _a, _b;
+        const config = configuration_1.Configuration.getInstance();
+        this.description = `TThe type MUST be one of the configured values (${(_a = config === null || config === void 0 ? void 0 : config.types) === null || _a === void 0 ? void 0 : _a.join(", ")}).`;
+        if (config.types === undefined || ((_b = config.types) === null || _b === void 0 ? void 0 : _b.length) === 0)
+            return;
+        if (commit.type.value !== undefined && config.types.includes(commit.type.value))
+            return;
+        const error = new RequirementError(this, commit);
+        error.addError("type MUST be one of the configured values", "type");
+        throw error;
+    }
+}
+/**
  * A Pull Request title MUST correlate with a Semantic Versioning identifier (`MAJOR`, `MINOR`,
  * or `PATCH`) with the same or higher precedence than its associated commits.
  */
@@ -15939,7 +16037,7 @@ class PR01 {
             throw error;
     }
 }
-const commitRules = [new CC01(), new CC04(), new CC05()];
+const commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
 exports.commitRules = commitRules;
 const pullRequestRules = [new PR01()];
 exports.pullRequestRules = pullRequestRules;

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -15195,6 +15195,43 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
+/***/ 5778:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
+/**
+ * Configuration class
+ * @class Configuration
+ * @member includeCommits Include commits in the validation process
+ * @member includePullRequest Include pull requests in the validation process
+ * @member scopes List of scopes to validate against
+ * @member types List of types to validate against
+ */
+class Configuration {
+    constructor() {
+        this.includeCommits = false;
+        this.includePullRequest = false;
+    }
+    static getInstance() {
+        if (!Configuration._instance) {
+            Configuration._instance = new Configuration();
+        }
+        return Configuration._instance;
+    }
+}
+exports.Configuration = Configuration;
+
+
+/***/ }),
+
 /***/ 2775:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -15427,6 +15464,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const commander_1 = __nccwpck_require__(4379);
 const datasources_1 = __nccwpck_require__(1751);
 const validator_1 = __nccwpck_require__(4630);
+const configuration_1 = __nccwpck_require__(5778);
 const program = new commander_1.Command();
 /**
  * Main entry point for the CLI tool.
@@ -15439,11 +15477,19 @@ program
     .command("check")
     .description("Checks whether your commit messagesare compliant with the Conventional Commit specification.")
     .option("-b, --base-branch <branch>", "The base branch to compare the current branch with.")
+    .option("-s, --scopes [scopes...]", "Conventional Commits scopes to validate against.")
+    .option("-t, --types [types...]", "Conventional Commits types to validate against.")
     .action((options) => __awaiter(void 0, void 0, void 0, function* () {
-    var _a;
+    var _a, _b, _c;
     console.log("📄 CommitMe - Conventional Commit compliance validation");
     console.log("-------------------------------------------------------");
-    const datasource = new datasources_1.GitSource((_a = options.baseBranch) !== null && _a !== void 0 ? _a : "main");
+    // Set the global configuration
+    const config = configuration_1.Configuration.getInstance();
+    config.includeCommits = true;
+    config.includePullRequest = false;
+    config.scopes = (_a = options.scopes) !== null && _a !== void 0 ? _a : [];
+    config.types = (_b = options.types) !== null && _b !== void 0 ? _b : [];
+    const datasource = new datasources_1.GitSource((_c = options.baseBranch) !== null && _c !== void 0 ? _c : "main");
     const commits = yield datasource.getCommitMessages();
     let errorCount = 0;
     const results = (0, validator_1.validateCommits)(commits);
@@ -15532,6 +15578,7 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.RequirementError = exports.pullRequestRules = exports.commitRules = void 0;
+const configuration_1 = __nccwpck_require__(5778);
 const logging_1 = __nccwpck_require__(1517);
 /**
  * Error thrown when a commit message does not meet the Conventional Commit specification.
@@ -15662,6 +15709,48 @@ class CC05 {
     }
 }
 /**
+ * The scope is REQUIRED and the value MUST be one of the configured values (...)
+ */
+class EC01 {
+    constructor() {
+        this.id = "EC-01";
+        this.description = "The scope is REQUIRED and the value MUST be one of the configured values (...)";
+    }
+    validate(commit) {
+        var _a, _b;
+        const config = configuration_1.Configuration.getInstance();
+        this.description = `The scope is REQUIRED and the value MUST be one of the configured values (${(_a = config === null || config === void 0 ? void 0 : config.scopes) === null || _a === void 0 ? void 0 : _a.join(", ")}).`;
+        if (config.scopes === undefined || ((_b = config.scopes) === null || _b === void 0 ? void 0 : _b.length) === 0)
+            return;
+        if (commit.scope.value !== undefined && config.scopes.includes(commit.scope.value.replace(/[()]+/g, "")))
+            return;
+        const error = new RequirementError(this, commit);
+        error.addError(["scope is REQUIRED", "and", "MUST be one of the configured values"], "scope");
+        throw error;
+    }
+}
+/**
+ * The type MUST be one of the configured values (...)
+ */
+class EC02 {
+    constructor() {
+        this.id = "EC-02";
+        this.description = "The type MUST be one of the configured values (...)";
+    }
+    validate(commit) {
+        var _a, _b;
+        const config = configuration_1.Configuration.getInstance();
+        this.description = `TThe type MUST be one of the configured values (${(_a = config === null || config === void 0 ? void 0 : config.types) === null || _a === void 0 ? void 0 : _a.join(", ")}).`;
+        if (config.types === undefined || ((_b = config.types) === null || _b === void 0 ? void 0 : _b.length) === 0)
+            return;
+        if (commit.type.value !== undefined && config.types.includes(commit.type.value))
+            return;
+        const error = new RequirementError(this, commit);
+        error.addError("type MUST be one of the configured values", "type");
+        throw error;
+    }
+}
+/**
  * A Pull Request title MUST correlate with a Semantic Versioning identifier (`MAJOR`, `MINOR`,
  * or `PATCH`) with the same or higher precedence than its associated commits.
  */
@@ -15695,7 +15784,7 @@ class PR01 {
             throw error;
     }
 }
-const commitRules = [new CC01(), new CC04(), new CC05()];
+const commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
 exports.commitRules = commitRules;
 const pullRequestRules = [new PR01()];
 exports.pullRequestRules = pullRequestRules;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,37 @@
+/*
+SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
+/**
+ * Configuration class
+ * @class Configuration
+ * @member includeCommits Include commits in the validation process
+ * @member includePullRequest Include pull requests in the validation process
+ * @member scopes List of scopes to validate against
+ * @member types List of types to validate against
+ */
+class Configuration {
+  private static _instance: Configuration;
+
+  includeCommits: boolean;
+  includePullRequest: boolean;
+  scopes?: string[];
+  types?: string[];
+
+  private constructor() {
+    this.includeCommits = false;
+    this.includePullRequest = false;
+  }
+
+  public static getInstance() {
+    if (!Configuration._instance) {
+      Configuration._instance = new Configuration();
+    }
+
+    return Configuration._instance;
+  }
+}
+
+export { Configuration };

--- a/src/entrypoints/cli.ts
+++ b/src/entrypoints/cli.ts
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 import { Command } from "commander";
 import { GitSource } from "../datasources";
 import { validateCommits } from "../validator";
+import { Configuration } from "../configuration";
 
 const program = new Command();
 
@@ -24,9 +25,18 @@ program
   .command("check")
   .description("Checks whether your commit messagesare compliant with the Conventional Commit specification.")
   .option("-b, --base-branch <branch>", "The base branch to compare the current branch with.")
+  .option("-s, --scopes [scopes...]", "Conventional Commits scopes to validate against.")
+  .option("-t, --types [types...]", "Conventional Commits types to validate against.")
   .action(async options => {
     console.log("📄 CommitMe - Conventional Commit compliance validation");
     console.log("-------------------------------------------------------");
+
+    // Set the global configuration
+    const config = Configuration.getInstance();
+    config.includeCommits = true;
+    config.includePullRequest = false;
+    config.scopes = options.scopes ?? [];
+    config.types = options.types ?? [];
 
     const datasource = new GitSource(options.baseBranch ?? "main");
     const commits = await datasource.getCommitMessages();

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 
 import { IConventionalCommit, IConventionalCommitElement, IRawConventionalCommit } from "./conventional_commit";
+import { Configuration } from "./configuration";
 import { ExpressiveMessage } from "./logging";
 
 /**
@@ -193,6 +194,48 @@ class CC05 implements ICommitRequirement {
 }
 
 /**
+ * The scope is REQUIRED and the value MUST be one of the configured values (...)
+ */
+class EC01 implements ICommitRequirement {
+  id = "EC-01";
+  description = "The scope is REQUIRED and the value MUST be one of the configured values (...)";
+
+  validate(commit: IRawConventionalCommit) {
+    const config = Configuration.getInstance();
+
+    this.description = `The scope is REQUIRED and the value MUST be one of the configured values (${config?.scopes?.join(
+      ", "
+    )}).`;
+    if (config.scopes === undefined || config.scopes?.length === 0) return;
+    if (commit.scope.value !== undefined && config.scopes.includes(commit.scope.value.replace(/[()]+/g, ""))) return;
+
+    const error = new RequirementError(this, commit);
+    error.addError(["scope is REQUIRED", "and", "MUST be one of the configured values"], "scope");
+    throw error;
+  }
+}
+
+/**
+ * The type MUST be one of the configured values (...)
+ */
+class EC02 implements ICommitRequirement {
+  id = "EC-02";
+  description = "The type MUST be one of the configured values (...)";
+
+  validate(commit: IRawConventionalCommit) {
+    const config = Configuration.getInstance();
+
+    this.description = `TThe type MUST be one of the configured values (${config?.types?.join(", ")}).`;
+    if (config.types === undefined || config.types?.length === 0) return;
+    if (commit.type.value !== undefined && config.types.includes(commit.type.value)) return;
+
+    const error = new RequirementError(this, commit);
+    error.addError("type MUST be one of the configured values", "type");
+    throw error;
+  }
+}
+
+/**
  * A Pull Request title MUST correlate with a Semantic Versioning identifier (`MAJOR`, `MINOR`,
  * or `PATCH`) with the same or higher precedence than its associated commits.
  */
@@ -228,7 +271,7 @@ class PR01 implements IPullRequestRequirement {
   }
 }
 
-const commitRules: ICommitRequirement[] = [new CC01(), new CC04(), new CC05()];
+const commitRules: ICommitRequirement[] = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
 const pullRequestRules: IPullRequestRequirement[] = [new PR01()];
 
 export { commitRules, pullRequestRules, RequirementError };

--- a/test/conventional_commit.test.ts
+++ b/test/conventional_commit.test.ts
@@ -4,6 +4,7 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: GPL-3.0-or-later
 */
 
+import { Configuration } from "../src/configuration";
 import * as commit from "../src/conventional_commit";
 import * as requirements from "../src/requirements";
 
@@ -42,7 +43,7 @@ const validateRequirement = (message: string, expected: string) => {
 /**
  * Validates that the commit message is a valid conventional commit.
  */
-describe("validate", () => {
+describe("Conventional Commits specification", () => {
   test("Valid Conventional Commit subjects", () => {
     for (const subject of [
       "feat: add new feature",
@@ -66,7 +67,7 @@ describe("validate", () => {
     }
   });
 
-  test("Requirement1", () => {
+  test("CC-01", () => {
     for (const message of [
       "(scope): missing type",
       ": missing type",
@@ -92,7 +93,7 @@ describe("validate", () => {
     }
   });
 
-  test("Requirement4", () => {
+  test("CC-04", () => {
     for (const message of [
       "feat(): empty scope",
       "feat(a noun): scope with spacing",
@@ -107,12 +108,35 @@ describe("validate", () => {
     }
   });
 
-  test("Requirement5", () => {
+  test("CC-05", () => {
     for (const message of ["feat:", "feat: ", "feat:    ", "feat:   too many spaces after terminal colon"]) {
       validateRequirement(
         message,
         "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string."
       );
+    }
+  });
+});
+
+describe("Extended Conventional Commits specification", () => {
+  beforeAll(() => {
+    const config = Configuration.getInstance();
+    config.scopes = ["action", "cli"];
+    config.types = ["feat", "fix"];
+  });
+
+  test("EC-01", () => {
+    for (const message of ["feat(wrong): unknown scope", "feat: no scope"]) {
+      validateRequirement(
+        message,
+        "The scope is REQUIRED and the value MUST be one of the configured values (action, cli)."
+      );
+    }
+  });
+
+  test("EC-02", () => {
+    for (const message of ["chore: unknown type", "docs(scope)!: unknown type"]) {
+      validateRequirement(message, "The type MUST be one of the configured values (feat, fix).");
     }
   });
 });


### PR DESCRIPTION
Introduces the ability to limit the Conventional Commits `type` and
`scope` based on the provided configuration values.