### PR TITLE
fix: unknown types should not be accepted by default

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -2650,7 +2650,7 @@ function highlightString(str, substring) {
     return result;
 }
 function createError(commit, description, highlight, type) {
-    var _a;
+    var _a, _b;
     const data = commit[type.toString()];
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
@@ -2660,7 +2660,7 @@ function createError(commit, description, highlight, type) {
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2750,46 +2750,47 @@ class CC05 {
     }
 }
 /**
- * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis
+ * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
     constructor() {
         this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis";
+        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${(_a = options === null || options === void 0 ? void 0 : options.scopes) === null || _a === void 0 ? void 0 : _a.join(", ")}) surrounded by parenthesis`;
-        if (options === undefined || options.scopes === undefined || options.scopes.length === 0)
+        var _a;
+        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
+        if (uniqueScopeList.length === 0)
             return [];
-        if (commit.scope.value === undefined || options.scopes.includes(commit.scope.value.replace(/[()]+/g, "")))
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
             return [];
+        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${(_b = options === null || options === void 0 ? void 0 : options.scopes) === null || _b === void 0 ? void 0 : _b.join(", ")})`], "scope"),
+            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
 /**
- * Commits MUST be prefixed with a type, which consists of one of the configured values (...)
+ * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
     constructor() {
         this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (...)";
+        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${[
-            "feat",
-            "fix",
-            ...((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []),
-        ].join(", ")}).`;
-        if (options === undefined || options.types === undefined || options.types.length === 0)
-            return [];
-        if (commit.type.value !== undefined && ["feat", "fix", ...options.types].includes(commit.type.value))
+        var _a;
+        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        if (uniqueAddedTypes.has("feat"))
+            uniqueAddedTypes.delete("feat");
+        if (uniqueAddedTypes.has("fix"))
+            uniqueAddedTypes.delete("fix");
+        const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
+        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
             return [];
         return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${["feat", "fix", ...((_b = options === null || options === void 0 ? void 0 : options.types) !== null && _b !== void 0 ? _b : [])].join(", ")})`], "type"),
+            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];
     }
 }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2651,7 +2651,7 @@ function highlightString(str, substring) {
     return result;
 }
 function createError(commit, description, highlight, type) {
-    var _a;
+    var _a, _b;
     const data = commit[type.toString()];
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
@@ -2661,7 +2661,7 @@ function createError(commit, description, highlight, type) {
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2751,46 +2751,47 @@ class CC05 {
     }
 }
 /**
- * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis
+ * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
     constructor() {
         this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis";
+        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${(_a = options === null || options === void 0 ? void 0 : options.scopes) === null || _a === void 0 ? void 0 : _a.join(", ")}) surrounded by parenthesis`;
-        if (options === undefined || options.scopes === undefined || options.scopes.length === 0)
+        var _a;
+        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
+        if (uniqueScopeList.length === 0)
             return [];
-        if (commit.scope.value === undefined || options.scopes.includes(commit.scope.value.replace(/[()]+/g, "")))
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
             return [];
+        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${(_b = options === null || options === void 0 ? void 0 : options.scopes) === null || _b === void 0 ? void 0 : _b.join(", ")})`], "scope"),
+            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
 /**
- * Commits MUST be prefixed with a type, which consists of one of the configured values (...)
+ * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
     constructor() {
         this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (...)";
+        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${[
-            "feat",
-            "fix",
-            ...((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []),
-        ].join(", ")}).`;
-        if (options === undefined || options.types === undefined || options.types.length === 0)
-            return [];
-        if (commit.type.value !== undefined && ["feat", "fix", ...options.types].includes(commit.type.value))
+        var _a;
+        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        if (uniqueAddedTypes.has("feat"))
+            uniqueAddedTypes.delete("feat");
+        if (uniqueAddedTypes.has("fix"))
+            uniqueAddedTypes.delete("fix");
+        const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
+        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
             return [];
         return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${["feat", "fix", ...((_b = options === null || options === void 0 ? void 0 : options.types) !== null && _b !== void 0 ? _b : [])].join(", ")})`], "type"),
+            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];
     }
 }

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -2651,7 +2651,7 @@ function highlightString(str, substring) {
     return result;
 }
 function createError(commit, description, highlight, type) {
-    var _a;
+    var _a, _b;
     const data = commit[type.toString()];
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
@@ -2661,7 +2661,7 @@ function createError(commit, description, highlight, type) {
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2751,46 +2751,47 @@ class CC05 {
     }
 }
 /**
- * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis
+ * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
     constructor() {
         this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (feat, fix, ...) surrounded by parenthesis";
+        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${(_a = options === null || options === void 0 ? void 0 : options.scopes) === null || _a === void 0 ? void 0 : _a.join(", ")}) surrounded by parenthesis`;
-        if (options === undefined || options.scopes === undefined || options.scopes.length === 0)
+        var _a;
+        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
+        if (uniqueScopeList.length === 0)
             return [];
-        if (commit.scope.value === undefined || options.scopes.includes(commit.scope.value.replace(/[()]+/g, "")))
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
             return [];
+        this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${(_b = options === null || options === void 0 ? void 0 : options.scopes) === null || _b === void 0 ? void 0 : _b.join(", ")})`], "scope"),
+            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
 /**
- * Commits MUST be prefixed with a type, which consists of one of the configured values (...)
+ * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
     constructor() {
         this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (...)";
+        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     }
     validate(commit, options) {
-        var _a, _b;
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${[
-            "feat",
-            "fix",
-            ...((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []),
-        ].join(", ")}).`;
-        if (options === undefined || options.types === undefined || options.types.length === 0)
-            return [];
-        if (commit.type.value !== undefined && ["feat", "fix", ...options.types].includes(commit.type.value))
+        var _a;
+        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        if (uniqueAddedTypes.has("feat"))
+            uniqueAddedTypes.delete("feat");
+        if (uniqueAddedTypes.has("fix"))
+            uniqueAddedTypes.delete("fix");
+        const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
+        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
             return [];
         return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${["feat", "fix", ...((_b = options === null || options === void 0 ? void 0 : options.types) !== null && _b !== void 0 ? _b : [])].join(", ")})`], "type"),
+            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -743,9 +743,9 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.2.tgz",
-      "integrity": "sha512-iWpvzcrmesZCXbizeXeIS6i1328g2kQ6DsqyjiRh8tCKv8tF7uavYA+tksdVOl8GN1qQeXINtg4fKjQkGRCwFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.3.tgz",
+      "integrity": "sha512-DygiSA/TdIF2jIhEOs1Tr5LXpYXlYdfPiUezTv5OSzcgRsGzOFky0P48uM/fLnaFXHteuL7iDogQL3egTbbbJw==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -34,11 +34,12 @@ describe("Validate commit messages", () => {
       },
     ]);
     let count = 0;
-    result.forEach(item => (count += item.errors.length));
+    result.forEach(item => count += item.errors.length);
 
     // Space in between type and scope
+    // Scope is not supported
     // Scope is not a noun
-    expect(count).toBe(2);
+    expect(count).toBe(3);
   });
 
   test("Valid Pull Request message", () => {
@@ -93,8 +94,9 @@ describe("Validate commit messages", () => {
     );
 
     // Space in between type and scope
+    // Scope is not supported
     // Scope is not a noun
-    expect(result.errors.length).toBe(2);
+    expect(result.errors.length).toBe(3);
   });
 
   test("Pull Request > Commits", () => {


### PR DESCRIPTION
The validation on Conventional Commit types was only working correctly in case the user would provide a list of additional types.

This could therefor result in the following commit subject to be accepted:
```
hippopotamus: feed it coleslaw
```