### PR TITLE
fix: add support for whitespace highlighting in error messages

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -2339,8 +2339,8 @@ exports.isConventionalCommit = isConventionalCommit;
  * @returns Conventional Commit
  */
 function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e, _f;
-    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
+    var _a, _b, _c, _d, _e;
+    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
     const match = ConventionalCommitRegex.exec(commit.subject);
     let conventionalCommit = {
         commit: commit,
@@ -2348,17 +2348,15 @@ function getConventionalCommit(commit, options) {
         scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
         breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
         seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        spacing: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
-        description: { index: 1, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
+        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
         commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
         commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.spacing.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
-        commit.description.index = commit.spacing.index + ((_k = (_j = commit.spacing.value) === null || _j === void 0 ? void 0 : _j.length) !== null && _k !== void 0 ? _k : 0);
+        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
         return commit;
     }
     conventionalCommit = intializeIndices(conventionalCommit);
@@ -2640,6 +2638,9 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+function isNoun(str) {
+    return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
+}
 function highlightString(str, substring) {
     // Ensure that we handle both single and multiple substrings equally
     if (!Array.isArray(substring))
@@ -2649,18 +2650,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type) {
-    var _a, _b;
-    const data = commit[type.toString()];
+function createError(commit, description, highlight, type, whitespace = false) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    const element = commit[type];
+    let hintIndex = element.index;
+    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    if (whitespace) {
+        let prevElement = undefined;
+        for (const [_key, value] of Object.entries(commit)) {
+            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+                prevElement = value;
+            }
+        }
+        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
+        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+    }
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
         linenumber: 1,
-        column: data.index,
+        column: hintIndex,
     })
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2671,40 +2684,38 @@ class CC01 {
         this.id = "CC-01";
         this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
         if (!commit.type.value || commit.type.value.trim().length === 0) {
-            errors.push(createError(commit, this.description, "MUST be prefixed with a type", "type"));
+            // Validated with EC-02
         }
         else {
             // Ensure that we have a noun
-            if (commit.type.value.trim().includes(" ") || /[^a-z]/i.test(commit.type.value.trim()))
+            if (!isNoun(commit.type.value))
                 errors.push(createError(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
                 if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
                 else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
                 else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
             }
             // Validate for spacing after the scope, breaking and seperator
-            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value)
-                errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
+                if (commit.breaking.value)
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                else
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
             if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
-            if (commit.seperator.value && commit.seperator.value.trim() !== commit.seperator.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
         }
         // MUST have a terminal colon
         if (!commit.seperator.value)
             errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
-        // MUST have a space after the terminal colon
-        else if (!commit.spacing.value || commit.spacing.value.length !== 1)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED", "space"], "spacing"));
         return errors;
     }
 }
@@ -2717,13 +2728,11 @@ class CC04 {
         this.id = "CC-04";
         this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
-            (commit.scope.value.includes(" ") ||
-                commit.scope.value === "()" ||
-                /[^a-z]/i.test(commit.scope.value.substring(1, commit.scope.value.length - 1)))) {
+            (commit.scope.value === "()" ||
+                !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
             errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
@@ -2739,13 +2748,13 @@ class CC05 {
         this.id = "CC-05";
         this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (!commit.seperator.value)
             return errors;
-        if (!commit.spacing.value || commit.spacing.value.length > 1 || !commit.description.value)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description"));
+        if (commit.description.value === undefined ||
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
+            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
         return errors;
     }
 }
@@ -2787,8 +2796,13 @@ class EC02 {
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
         this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
-        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
+        if (commit.type.value === undefined ||
+            !isNoun(commit.type.value) ||
+            expectedTypes.includes(commit.type.value.trimEnd()))
             return [];
+        if (commit.type.value.trim().length === 0) {
+            return [createError(commit, this.description, "prefixed with a type", "type")];
+        }
         return [
             createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2340,8 +2340,8 @@ exports.isConventionalCommit = isConventionalCommit;
  * @returns Conventional Commit
  */
 function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e, _f;
-    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
+    var _a, _b, _c, _d, _e;
+    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
     const match = ConventionalCommitRegex.exec(commit.subject);
     let conventionalCommit = {
         commit: commit,
@@ -2349,17 +2349,15 @@ function getConventionalCommit(commit, options) {
         scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
         breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
         seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        spacing: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
-        description: { index: 1, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
+        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
         commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
         commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.spacing.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
-        commit.description.index = commit.spacing.index + ((_k = (_j = commit.spacing.value) === null || _j === void 0 ? void 0 : _j.length) !== null && _k !== void 0 ? _k : 0);
+        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
         return commit;
     }
     conventionalCommit = intializeIndices(conventionalCommit);
@@ -2641,6 +2639,9 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+function isNoun(str) {
+    return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
+}
 function highlightString(str, substring) {
     // Ensure that we handle both single and multiple substrings equally
     if (!Array.isArray(substring))
@@ -2650,18 +2651,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type) {
-    var _a, _b;
-    const data = commit[type.toString()];
+function createError(commit, description, highlight, type, whitespace = false) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    const element = commit[type];
+    let hintIndex = element.index;
+    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    if (whitespace) {
+        let prevElement = undefined;
+        for (const [_key, value] of Object.entries(commit)) {
+            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+                prevElement = value;
+            }
+        }
+        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
+        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+    }
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
         linenumber: 1,
-        column: data.index,
+        column: hintIndex,
     })
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2672,40 +2685,38 @@ class CC01 {
         this.id = "CC-01";
         this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
         if (!commit.type.value || commit.type.value.trim().length === 0) {
-            errors.push(createError(commit, this.description, "MUST be prefixed with a type", "type"));
+            // Validated with EC-02
         }
         else {
             // Ensure that we have a noun
-            if (commit.type.value.trim().includes(" ") || /[^a-z]/i.test(commit.type.value.trim()))
+            if (!isNoun(commit.type.value))
                 errors.push(createError(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
                 if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
                 else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
                 else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
             }
             // Validate for spacing after the scope, breaking and seperator
-            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value)
-                errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
+                if (commit.breaking.value)
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                else
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
             if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
-            if (commit.seperator.value && commit.seperator.value.trim() !== commit.seperator.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
         }
         // MUST have a terminal colon
         if (!commit.seperator.value)
             errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
-        // MUST have a space after the terminal colon
-        else if (!commit.spacing.value || commit.spacing.value.length !== 1)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED", "space"], "spacing"));
         return errors;
     }
 }
@@ -2718,13 +2729,11 @@ class CC04 {
         this.id = "CC-04";
         this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
-            (commit.scope.value.includes(" ") ||
-                commit.scope.value === "()" ||
-                /[^a-z]/i.test(commit.scope.value.substring(1, commit.scope.value.length - 1)))) {
+            (commit.scope.value === "()" ||
+                !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
             errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
@@ -2740,13 +2749,13 @@ class CC05 {
         this.id = "CC-05";
         this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (!commit.seperator.value)
             return errors;
-        if (!commit.spacing.value || commit.spacing.value.length > 1 || !commit.description.value)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description"));
+        if (commit.description.value === undefined ||
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
+            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
         return errors;
     }
 }
@@ -2788,8 +2797,13 @@ class EC02 {
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
         this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
-        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
+        if (commit.type.value === undefined ||
+            !isNoun(commit.type.value) ||
+            expectedTypes.includes(commit.type.value.trimEnd()))
             return [];
+        if (commit.type.value.trim().length === 0) {
+            return [createError(commit, this.description, "prefixed with a type", "type")];
+        }
         return [
             createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -2340,8 +2340,8 @@ exports.isConventionalCommit = isConventionalCommit;
  * @returns Conventional Commit
  */
 function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e, _f;
-    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
+    var _a, _b, _c, _d, _e;
+    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
     const match = ConventionalCommitRegex.exec(commit.subject);
     let conventionalCommit = {
         commit: commit,
@@ -2349,17 +2349,15 @@ function getConventionalCommit(commit, options) {
         scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
         breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
         seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        spacing: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
-        description: { index: 1, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
+        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
         commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
         commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.spacing.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
-        commit.description.index = commit.spacing.index + ((_k = (_j = commit.spacing.value) === null || _j === void 0 ? void 0 : _j.length) !== null && _k !== void 0 ? _k : 0);
+        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
         return commit;
     }
     conventionalCommit = intializeIndices(conventionalCommit);
@@ -2641,6 +2639,9 @@ SPDX-License-Identifier: CC-BY-3.0
 */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+function isNoun(str) {
+    return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
+}
 function highlightString(str, substring) {
     // Ensure that we handle both single and multiple substrings equally
     if (!Array.isArray(substring))
@@ -2650,18 +2651,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type) {
-    var _a, _b;
-    const data = commit[type.toString()];
+function createError(commit, description, highlight, type, whitespace = false) {
+    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+    const element = commit[type];
+    let hintIndex = element.index;
+    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    if (whitespace) {
+        let prevElement = undefined;
+        for (const [_key, value] of Object.entries(commit)) {
+            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+                prevElement = value;
+            }
+        }
+        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
+        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+    }
     return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
         text: highlightString(description, highlight),
         linenumber: 1,
-        column: data.index,
+        column: hintIndex,
     })
         .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject])
-        .addFixitHint(diagnose_it_1.FixItHint.create({ index: data.index, length: (_b = (_a = data.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 1 }));
+        .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
  * Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc.,
@@ -2672,40 +2685,38 @@ class CC01 {
         this.id = "CC-01";
         this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
         if (!commit.type.value || commit.type.value.trim().length === 0) {
-            errors.push(createError(commit, this.description, "MUST be prefixed with a type", "type"));
+            // Validated with EC-02
         }
         else {
             // Ensure that we have a noun
-            if (commit.type.value.trim().includes(" ") || /[^a-z]/i.test(commit.type.value.trim()))
+            if (!isNoun(commit.type.value))
                 errors.push(createError(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
                 if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
                 else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
                 else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
             }
             // Validate for spacing after the scope, breaking and seperator
-            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value)
-                errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope"));
+            if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
+                if (commit.breaking.value)
+                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                else
+                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
             if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking"));
-            if (commit.seperator.value && commit.seperator.value.trim() !== commit.seperator.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
         }
         // MUST have a terminal colon
         if (!commit.seperator.value)
             errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
-        // MUST have a space after the terminal colon
-        else if (!commit.spacing.value || commit.spacing.value.length !== 1)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED", "space"], "spacing"));
         return errors;
     }
 }
@@ -2718,13 +2729,11 @@ class CC04 {
         this.id = "CC-04";
         this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
-            (commit.scope.value.includes(" ") ||
-                commit.scope.value === "()" ||
-                /[^a-z]/i.test(commit.scope.value.substring(1, commit.scope.value.length - 1)))) {
+            (commit.scope.value === "()" ||
+                !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
             errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
@@ -2740,13 +2749,13 @@ class CC05 {
         this.id = "CC-05";
         this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     validate(commit, _options) {
         const errors = [];
         if (!commit.seperator.value)
             return errors;
-        if (!commit.spacing.value || commit.spacing.value.length > 1 || !commit.description.value)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description"));
+        if (commit.description.value === undefined ||
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
+            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
         return errors;
     }
 }
@@ -2788,8 +2797,13 @@ class EC02 {
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
         this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
-        if (commit.type.value !== undefined && expectedTypes.includes(commit.type.value))
+        if (commit.type.value === undefined ||
+            !isNoun(commit.type.value) ||
+            expectedTypes.includes(commit.type.value.trimEnd()))
             return [];
+        if (commit.type.value.trim().length === 0) {
+            return [createError(commit, this.description, "prefixed with a type", "type")];
+        }
         return [
             createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
         ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -743,9 +743,9 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.3.tgz",
-      "integrity": "sha512-DygiSA/TdIF2jIhEOs1Tr5LXpYXlYdfPiUezTv5OSzcgRsGzOFky0P48uM/fLnaFXHteuL7iDogQL3egTbbbJw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.4.tgz",
+      "integrity": "sha512-dT0bfSmDnj2SD4qVedHuwTIozOcKwEOb5RulndCjXUSJ2IazA3U3VJMyqAf0TTY9h7au/HaKjokjMtomNNi+XA==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -37,9 +37,8 @@ describe("Validate commit messages", () => {
     result.forEach(item => count += item.errors.length);
 
     // Space in between type and scope
-    // Scope is not supported
     // Scope is not a noun
-    expect(count).toBe(3);
+    expect(count).toBe(2);
   });
 
   test("Valid Pull Request message", () => {
@@ -94,9 +93,8 @@ describe("Validate commit messages", () => {
     );
 
     // Space in between type and scope
-    // Scope is not supported
     // Scope is not a noun
-    expect(result.errors.length).toBe(3);
+    expect(result.errors.length).toBe(2);
   });
 
   test("Pull Request > Commits", () => {


### PR DESCRIPTION
This commit will improve the error messages generated for the different use cases where Conventional Commit elements are seperated by an incorrect amount of spacing.

Instead of placing the FixIt hints on the next element, it will now correctly cover the added (and missing) white spacing.