### PR TITLE
feat: extend Conventional Commit ruleset to provide better feedback

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -2093,9 +2093,9 @@ function isLoopbackAddress(host) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2120,8 +2120,75 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommit = exports.isConventionalCommit = exports.parseCommitMessage = void 0;
+exports.parseCommitMessage = exports.getFooterElementsFromParagraph = exports.Commit = void 0;
 const git = __importStar(__nccwpck_require__(8433));
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
+/**
+ * Git Commit
+ * @class Commit
+ * @member author The commit author and date
+ * @member commiter The commit commiter and date
+ * @member hash The commit hash
+ * @member subject The commit subject
+ * @member body The commit body
+ * @member footer The commit footer
+ * @member raw The commit message
+ */
+class Commit {
+    _commit;
+    constructor(commit) {
+        this._commit = commit;
+    }
+    /**
+     * Retrieves the commit information from git using the provided hash
+     * @param props The commit hash and root path
+     * @returns The commit object
+     */
+    static fromHash(props) {
+        const commit = git.getCommitFromHash(props.hash, props.rootPath ?? process.cwd());
+        return new Commit(commit);
+    }
+    /**
+     * Creates a Commit object from the provided string
+     * @param props The commit hash, author, committer and message
+     * @returns The commit object
+     */
+    static fromString(props) {
+        const commit = {
+            hash: props.hash,
+            ...parseCommitMessage(props.message),
+            author: props.author,
+            committer: props.committer,
+            raw: props.message,
+        };
+        return new Commit(commit);
+    }
+    get author() {
+        return this._commit.author;
+    }
+    get committer() {
+        return this._commit.committer;
+    }
+    get hash() {
+        return this._commit.hash;
+    }
+    get subject() {
+        return this._commit.subject;
+    }
+    get body() {
+        return this._commit.body;
+    }
+    get footer() {
+        return this._commit.footer;
+    }
+    get raw() {
+        return this._commit.raw;
+    }
+    toJSON() {
+        return this._commit;
+    }
+}
+exports.Commit = Commit;
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -2131,13 +2198,15 @@ const git = __importStar(__nccwpck_require__(8433));
  * The value is either:
  * - the remainder of the line
  * - the remainder of the line + anything that follows on the next lines which is indented by at least one space
+ *
+ * @internal
  */
-function parseCommitFooter(footer) {
-    const footerLines = footer.split(/[\r\n]+/);
-    const result = {};
+function getFooterElementsFromParagraph(footer) {
+    const footerLines = footer.split(/\r?\n/);
+    const result = [];
     for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
         const line = footerLines[lineNr];
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+        const match = TRAILER_REGEX.exec(line);
         if (match === null)
             continue;
         let key = match[1].replace(/:$/, "");
@@ -2146,15 +2215,22 @@ function parseCommitFooter(footer) {
             key = match[1].substring(0, match[1].length - 2);
             value = `#${value}`;
         }
+        const matchLine = lineNr;
         // Check if the value continues on the next line
-        while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+        while (lineNr + 1 < footerLines.length &&
+            (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)) {
             lineNr++;
             value += "\n" + footerLines[lineNr].trim();
         }
-        result[key] = value;
+        result.push({
+            lineNumber: matchLine + 1,
+            key,
+            value,
+        });
     }
     return Object.keys(result).length > 0 ? result : undefined;
 }
+exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
@@ -2163,11 +2239,11 @@ function parseCommitFooter(footer) {
  * @internal
  */
 function parseCommitMessage(message) {
-    const isTrailerOnly = (message) => message.split(/[\r\n]+/).every(line => {
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const isTrailerOnly = (message) => message.split(/\r?\n/).every(line => {
+        const match = TRAILER_REGEX.exec(line);
         return match !== null;
     });
-    const paragraphs = message.split(/^[\r\n]+/m);
+    const paragraphs = message.split(/^\r?\n/m);
     let footer = undefined;
     let body = undefined;
     if (paragraphs.length > 1 && isTrailerOnly(paragraphs[paragraphs.length - 1])) {
@@ -2182,69 +2258,26 @@ function parseCommitMessage(message) {
     return {
         subject: paragraphs[0].trim(),
         body: body,
-        footer: parseCommitFooter(footer !== null && footer !== void 0 ? footer : ""),
+        footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
+            acc[cur.key] = cur.value;
+            return acc;
+        }, {}),
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
-/**
- * Confirms whether the provided commit is a Conventional Commit
- * @param commit
- * @returns
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Retrieves the commit message (from the indicated source) given the provided SHA hash
- * @param hash SHA of the commit
- * @param source The data source to retrieve the commit message from (git or github)
- * @param options The options to use when retrieving the commit message
- * @returns Commit object
- */
-function getCommit(options) {
-    var _a;
-    let commit;
-    // String data source
-    if ("message" in options) {
-        const stringOptions = options;
-        commit = {
-            hash: stringOptions.hash,
-            ...parseCommitMessage(stringOptions.message),
-            author: stringOptions.author,
-            committer: stringOptions.committer,
-        };
-        // GitHub data source
-    }
-    else if ("owner" in options) {
-        const githubOptions = options;
-        // TODO; implement basic GitHub client
-        commit = {
-            hash: githubOptions.hash,
-            subject: "",
-        };
-        // Git data source
-    }
-    else {
-        const gitOptions = options;
-        commit = git.getCommitFromHash(gitOptions.hash, (_a = gitOptions.rootPath) !== null && _a !== void 0 ? _a : process.cwd());
-    }
-    return commit;
-}
-exports.getCommit = getCommit;
 
 
 /***/ }),
 
-/***/ 8436:
+/***/ 1124:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2268,101 +2301,162 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConventionalCommit = exports.isConventionalCommit = exports.ConventionalCommitError = void 0;
-const assert_1 = __importDefault(__nccwpck_require__(9491));
+exports.ConventionalCommit = void 0;
+const diagnose_it_1 = __nccwpck_require__(4657);
+const commit_1 = __nccwpck_require__(8065);
 const requirements = __importStar(__nccwpck_require__(4374));
 /**
- * Conventional Commit error
- * @class ConventionalCommitError
- * @extends Error
+ * Conventional Commit
+ * @class ConventionalCommit
+ * @member type Conventional Commit type
+ * @member scope Conventional Commit scope
+ * @member breaking Commit message has a Conventional Commit breaking change (!)
+ * @member description Conventional Commit description
+ * @member hash Commit hash
+ * @member subject Commit subject
+ * @member body Commit body
+ * @member footer Commit footer
+ * @member author Commit author and date
+ * @member committer Commit committer and date
+ * @member isValid Whether the Conventional Commit is valid
  * @member errors List of error messages
+ * @member warnings List of warning messages
  */
-class ConventionalCommitError extends Error {
-    constructor(errors) {
-        super("Commit is not compliant with the Conventional Commits specification.");
-        this.name = "ConventionalCommitError";
-        this.errors = errors;
+class ConventionalCommit {
+    _raw;
+    _errors = [];
+    _warnings = [];
+    constructor(raw, options) {
+        this._raw = raw;
+        this.validate(options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided Commit.
+     * @param commit Commit to convert to a Conventional Commit
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromCommit(commit, options) {
+        // Convert the Commit message to Raw Conventional Commit data
+        const rawConvCommit = createRawConventionalCommit(commit);
+        // Create a new Conventional Commit object
+        return new ConventionalCommit(rawConvCommit, options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided string.
+     * @param props Hash, message and author/committer information
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromString(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromString(props), options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided hash.
+     * @param props Hash and root path
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromHash(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromHash(props), options);
+    }
+    // Contributors
+    get author() {
+        return this._raw.commit.author;
+    }
+    get committer() {
+        return this._raw.commit.committer;
+    }
+    // Commit
+    get hash() {
+        return this._raw.commit.hash;
+    }
+    get subject() {
+        return this._raw.commit.subject;
+    }
+    get body() {
+        return this._raw.commit.body;
+    }
+    get footer() {
+        return this._raw.commit.footer;
+    }
+    // Conventional Commit
+    get type() {
+        return this._raw.type.value;
+    }
+    get scope() {
+        return this._raw.scope.value;
+    }
+    get description() {
+        return this._raw.description.value;
+    }
+    get breaking() {
+        return (this._raw.breaking.value === "!" ||
+            (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
+    }
+    // Raw
+    get raw() {
+        return this._raw.commit.raw;
+    }
+    // Validation
+    get isValid() {
+        return this._errors.length === 0;
+    }
+    get warnings() {
+        return this._warnings;
+    }
+    get errors() {
+        return this._errors;
+    }
+    toJSON() {
+        return {
+            hash: this.hash,
+            author: this.author,
+            committer: this.committer,
+            subject: this.subject,
+            body: this.body,
+            footer: this.footer,
+            type: this.type,
+            breaking: this.breaking,
+            description: this.description,
+            validation: {
+                isValid: this.isValid,
+                errors: this.errors,
+                warnings: this.warnings,
+            },
+        };
+    }
+    // Private validation function
+    validate(options) {
+        let results = [];
+        requirements.commitRules.forEach(rule => (results = [...results, ...rule.validate(this._raw, options)]));
+        this._errors = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Error);
+        this._warnings = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Warning);
     }
 }
-exports.ConventionalCommitError = ConventionalCommitError;
-/**
- * Returns whether the provided commit has a breaking change (either "!" in subject, or usage of /BREAKING[- ]CHANGE:/).
- * @param commit Commit to check
- * @returns Whether the provided commit has a breaking change
- */
-function hasBreakingChange(commit) {
-    return (commit.breaking.value === "!" ||
-        (commit.commit.footer !== undefined &&
-            ("BREAKING CHANGE" in commit.commit.footer || "BREAKING-CHANGE" in commit.commit.footer)));
-}
-/**
- * Validates a commit message against the Conventional Commit specification.
- * @param commit Commit message to validate against the Conventional Commit specification
- * @returns Conventional Commit mesage
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @see https://www.conventionalcommits.org/en/v1.0.0/
- */
-function validate(commit, options) {
-    let errors = [];
-    requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
-    if (errors.length > 0)
-        throw new ConventionalCommitError(errors);
-    // Assume that we have a valid Conventional Commit message
-    (0, assert_1.default)(commit.type.value);
-    (0, assert_1.default)(commit.description.value);
-    return {
-        ...commit.commit,
-        type: commit.type.value,
-        scope: commit.scope.value,
-        breaking: hasBreakingChange(commit),
-        description: commit.description.value,
-    };
-}
-/**
- * Returns whether the provided commit is a Conventional Commit.
- * @param commit Commit to check
- * @returns Whether the provided commit is a Conventional Commit
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Parses a Commit message into a Conventional Commit.
- * @param commit Commit message to parse
- * @param options Options to use when parsing the commit message
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @returns Conventional Commit
- */
-function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e;
+exports.ConventionalCommit = ConventionalCommit;
+function createRawConventionalCommit(commit) {
     const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
-    const match = ConventionalCommitRegex.exec(commit.subject);
-    let conventionalCommit = {
+    const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
+    const conventionalCommit = {
         commit: commit,
-        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
+        type: { index: 1, value: match?.groups?.type },
+        scope: { index: 1, value: match?.groups?.scope },
+        breaking: { index: 1, value: match?.groups?.breaking },
+        seperator: { index: 1, value: match?.groups?.separator },
+        description: { index: 1, value: match?.groups?.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
-        commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
-        commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
-        commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
+        commit.scope.index = commit.type.index + (commit.type.value?.length ?? 0);
+        commit.breaking.index = commit.scope.index + (commit.scope.value?.length ?? 0);
+        commit.seperator.index = commit.breaking.index + (commit.breaking.value?.length ?? 0);
+        commit.description.index = commit.seperator.index + (commit.seperator.value?.length ?? 0);
         return commit;
     }
-    conventionalCommit = intializeIndices(conventionalCommit);
-    return validate(conventionalCommit, options);
+    return intializeIndices(conventionalCommit);
 }
-exports.getConventionalCommit = getConventionalCommit;
 
 
 /***/ }),
@@ -2373,9 +2467,9 @@ exports.getConventionalCommit = getConventionalCommit;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2455,15 +2549,17 @@ function getValueFromKey(commit, key) {
 function parseCommitMessage(commit, hash) {
     const author = extractNameAndDate(getValueFromKey(commit, "author"));
     const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+    const raw = commit
+        .split(/^[\r\n]+/m)
+        .splice(1)
+        .join("\n")
+        .trim();
     return {
+        raw,
         hash: hash,
         author: author,
         committer: committer,
-        ...ccommit.parseCommitMessage(commit
-            .split(/^[\r\n]+/m)
-            .splice(1)
-            .join("\n")
-            .trim()),
+        ...ccommit.parseCommitMessage(raw),
     };
 }
 /**
@@ -2605,17 +2701,15 @@ function readPackFile(path, index) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ConventionalCommitError = exports.isConventionalCommit = exports.getConventionalCommit = exports.getCommit = void 0;
+exports.ConventionalCommit = exports.Commit = void 0;
 var commit_1 = __nccwpck_require__(8065);
-Object.defineProperty(exports, "getCommit", ({ enumerable: true, get: function () { return commit_1.getCommit; } }));
-var conventional_commit_1 = __nccwpck_require__(8436);
-Object.defineProperty(exports, "getConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.getConventionalCommit; } }));
-Object.defineProperty(exports, "isConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.isConventionalCommit; } }));
-Object.defineProperty(exports, "ConventionalCommitError", ({ enumerable: true, get: function () { return conventional_commit_1.ConventionalCommitError; } }));
+Object.defineProperty(exports, "Commit", ({ enumerable: true, get: function () { return commit_1.Commit; } }));
+var conventionalCommit_1 = __nccwpck_require__(1124);
+Object.defineProperty(exports, "ConventionalCommit", ({ enumerable: true, get: function () { return conventionalCommit_1.ConventionalCommit; } }));
 
 
 /***/ }),
@@ -2631,13 +2725,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitRules = void 0;
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: CC-BY-3.0
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: CC-BY-3.0
+ */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+const commit_1 = __nccwpck_require__(8065);
 function isNoun(str) {
     return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
 }
@@ -2650,29 +2745,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type, whitespace = false) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+function createDiagnosticsMessage(commit, description, highlight, type, whitespace = false, level = diagnose_it_1.DiagnosticsLevelEnum.Error) {
     const element = commit[type];
     let hintIndex = element.index;
-    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    let hintLength = element.value?.trimEnd().length ?? 1;
     if (whitespace) {
         let prevElement = undefined;
         for (const [_key, value] of Object.entries(commit)) {
-            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+            if (value.index > (prevElement?.index ?? 0) && value.index < element.index) {
                 prevElement = value;
             }
         }
-        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
-        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+        hintIndex = prevElement ? prevElement.index + (prevElement.value?.trimEnd().length ?? 1) : 1;
+        hintLength = (prevElement?.value?.length ?? 1) - (prevElement?.value?.trimEnd().length ?? 1);
     }
-    return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
-        text: highlightString(description, highlight),
-        linenumber: 1,
-        column: hintIndex,
+    return new diagnose_it_1.DiagnosticsMessage({
+        file: commit.commit.hash,
+        level,
+        message: {
+            text: highlightString(description, highlight),
+            linenumber: 1,
+            column: hintIndex,
+        },
     })
-        .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
-        ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
-        : [commit.commit.subject])
+        .setContext(1, commit.commit.subject.split(/\r?\n/)[0])
         .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
@@ -2680,10 +2776,8 @@ function createError(commit, description, highlight, type, whitespace = false) {
  * followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
  */
 class CC01 {
-    constructor() {
-        this.id = "CC-01";
-        this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
-    }
+    id = "CC-01";
+    description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
@@ -2693,29 +2787,36 @@ class CC01 {
         else {
             // Ensure that we have a noun
             if (!isNoun(commit.type.value))
-                errors.push(createError(commit, this.description, "which consists of a noun", "type"));
+                errors.push(createDiagnosticsMessage(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
-                if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
-                else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.scope.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
+                }
+                else if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
             // Validate for spacing after the scope, breaking and seperator
             if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
-                if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
-            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value) {
+                errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
         }
         // MUST have a terminal colon
-        if (!commit.seperator.value)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        if (!commit.seperator.value) {
+            errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        }
         return errors;
     }
 }
@@ -2724,16 +2825,14 @@ class CC01 {
  * a section of the codebase surrounded by parenthesis, e.g., fix(parser):
  */
 class CC04 {
-    constructor() {
-        this.id = "CC-04";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
-    }
+    id = "CC-04";
+    description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
             (commit.scope.value === "()" ||
                 !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
-            errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
+            errors.push(createDiagnosticsMessage(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
     }
@@ -2744,17 +2843,73 @@ class CC04 {
  * when multiple spaces were contained in string.
  */
 class CC05 {
-    constructor() {
-        this.id = "CC-05";
-        this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
-    }
+    id = "CC-05";
+    description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     validate(commit, _options) {
         const errors = [];
-        if (!commit.seperator.value)
+        if (!commit.seperator.value) {
             return errors;
+        }
         if (commit.description.value === undefined ||
-            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1) {
+            errors.push(createDiagnosticsMessage(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+        }
+        return errors;
+    }
+}
+/**
+ * A longer commit body MAY be provided after the short description, providing
+ * additional contextual information about the code changes. The body MUST begin one
+ * blank line after the description.
+ */
+class CC06 {
+    id = "CC-06";
+    description = "A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.";
+    validate(commit, _options) {
+        const errors = [];
+        if (!commit.commit.subject) {
+            return errors;
+        }
+        const lines = commit.commit.subject.split(/\r?\n/);
+        if (lines.length > 1) {
+            return [
+                diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                    text: highlightString(this.description, "The body MUST begin one blank line after the description"),
+                    linenumber: 2,
+                    column: 1,
+                })
+                    .setContext(1, lines)
+                    .addFixitHint(diagnose_it_1.FixItHint.createRemoval({ index: 1, length: lines[1].length })),
+            ];
+        }
+        return errors;
+    }
+}
+/**
+ * The units of information that make up Conventional Commits MUST NOT be treated as case
+ * sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+ */
+class CC15 {
+    id = "CC-15";
+    description = "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.";
+    validate(commit, _options) {
+        const errors = [];
+        const footerElements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.raw);
+        if (footerElements === undefined)
+            return errors;
+        for (const element of footerElements) {
+            if (["BREAKING CHANGE", "BREAKING-CHANGE"].includes(element.key.toUpperCase())) {
+                if (element.key !== element.key.toUpperCase()) {
+                    errors.push(diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                        text: highlightString(this.description, "BREAKING CHANGE MUST be uppercase"),
+                        linenumber: element.lineNumber,
+                        column: 1,
+                    })
+                        .setContext(element.lineNumber, commit.commit.raw.split(/\r?\n/)[element.lineNumber - 1])
+                        .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+                }
+            }
+        }
         return errors;
     }
 }
@@ -2762,20 +2917,19 @@ class CC05 {
  * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
-    constructor() {
-        this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
-    }
+    id = "EC-01";
+    description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     validate(commit, options) {
-        var _a;
-        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
-        if (uniqueScopeList.length === 0)
+        const uniqueScopeList = Array.from(new Set(options?.scopes ?? []));
+        if (uniqueScopeList.length === 0) {
             return [];
-        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
+        }
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, ""))) {
             return [];
+        }
         this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
+            createDiagnosticsMessage(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
@@ -2783,33 +2937,74 @@ class EC01 {
  * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
-    constructor() {
-        this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
-    }
+    id = "EC-02";
+    description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     validate(commit, options) {
-        var _a;
-        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        const uniqueAddedTypes = new Set(options?.types ?? []);
         if (uniqueAddedTypes.has("feat"))
             uniqueAddedTypes.delete("feat");
         if (uniqueAddedTypes.has("fix"))
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        this.description = `Commits ${uniqueAddedTypes.size > 0 ? "MUST" : "MAY"} be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
         if (commit.type.value === undefined ||
             !isNoun(commit.type.value) ||
-            expectedTypes.includes(commit.type.value.trimEnd()))
+            expectedTypes.includes(commit.type.value.toLowerCase().trimEnd())) {
             return [];
-        if (commit.type.value.trim().length === 0) {
-            return [createError(commit, this.description, "prefixed with a type", "type")];
         }
-        return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
-        ];
+        if (commit.type.value.trim().length === 0) {
+            return [createDiagnosticsMessage(commit, this.description, "prefixed with a type", "type")];
+        }
+        if (uniqueAddedTypes.size > 0) {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
+            ];
+        }
+        else {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type", false, diagnose_it_1.DiagnosticsLevelEnum.Warning),
+            ];
+        }
+    }
+}
+/**
+ * A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.
+ */
+class WA01 {
+    id = "WA-01";
+    description = "A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.";
+    validate(commit, _options) {
+        const errors = [];
+        if (commit.commit.body === undefined)
+            return errors;
+        const elements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.body);
+        if (elements === undefined)
+            return errors;
+        for (const element of elements) {
+            if (element.key === "BREAKING CHANGE" || element.key === "BREAKING-CHANGE") {
+                errors.push(diagnose_it_1.DiagnosticsMessage.createWarning(commit.commit.hash, {
+                    text: highlightString(`A \`${element.key}\` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.`, [element.key, "will be ignored as it MUST be included in the footer"]),
+                    linenumber: commit.commit.subject.split(/\r?\n/).length + element.lineNumber,
+                    column: 1,
+                })
+                    .setContext(commit.commit.subject.split(/\r?\n/).length + 1, commit.commit.body.split(/\r?\n/))
+                    .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+            }
+        }
+        return errors;
     }
 }
 /** @internal */
-exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
+exports.commitRules = [
+    new CC01(),
+    new CC04(),
+    new CC05(),
+    new CC06(),
+    new CC15(),
+    new EC01(),
+    new EC02(),
+    new WA01(),
+];
 
 
 /***/ }),
@@ -41011,7 +41206,7 @@ class FileSource {
         }
     }
     async getCommitMessages() {
-        return [(0, commit_it_1.getCommit)({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
+        return [commit_it_1.Commit.fromString({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41031,7 +41226,7 @@ class GitSource {
     }
     async getCommitMessages() {
         const data = await (0, simple_git_1.simpleGit)().log({ from: this.sourceBranch, to: "@{push}" });
-        return data.all.map(commit => (0, commit_it_1.getCommit)({ hash: commit.hash }));
+        return data.all.map(commit => commit_it_1.Commit.fromHash({ hash: commit.hash }));
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41050,13 +41245,10 @@ class GitHubSource {
         const pullRequestNumber = github.context.payload.pull_request?.number;
         (0, assert_1.default)(pullRequestNumber);
         const commits = await octokit.rest.pulls.listCommits({ ...github.context.repo, pull_number: pullRequestNumber });
-        return commits.data.map(commit => {
-            return {
-                hash: commit.sha,
-                subject: commit.commit.message.split(/\r?\n/)[0],
-                body: commit.commit.message.split(/\r?\n/).slice(2).join("\n"),
-            };
-        });
+        return commits.data.map(commit => commit_it_1.Commit.fromString({
+            hash: commit.sha,
+            message: commit.commit.message,
+        }));
     }
     /**
      * Retrieves the specified configuration file from the repository using the REST API
@@ -41141,14 +41333,13 @@ const validator_1 = __nccwpck_require__(4630);
 const determineLabel = async (commits) => {
     let type;
     for (const commit of commits) {
-        if (!(0, commit_it_1.isConventionalCommit)(commit.commit))
+        if (!commit.isValid)
             continue;
-        const convCommit = commit.commit;
-        if (convCommit.breaking)
+        if (commit.breaking)
             return "breaking";
-        if (convCommit.type === "feat")
+        if (commit.type?.toLowerCase() === "feat")
             type = "feature";
-        else if (convCommit.type === "fix" && type !== "feature")
+        else if (commit.type?.toLowerCase() === "fix" && type !== "feature")
             type = "fix";
     }
     return type;
@@ -41160,12 +41351,15 @@ const determineLabel = async (commits) => {
  */
 const reportErrorMessages = (results) => {
     let errorCount = 0;
+    let warningCount = 0;
     for (const commit of results) {
-        core.info(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.subject}`);
-        commit.errors.forEach(error => core.error(error, { title: "Conventional Commit Compliance" }));
+        core.info(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.hash}: ${commit.subject}`);
+        commit.errors.forEach(error => core.error(error.toString(), { title: "Conventional Commit Compliance" }));
         errorCount += commit.errors.length;
+        commit.warnings.forEach(warning => core.warning(warning.toString(), { title: "Conventional Commit Compliance" }));
+        warningCount += commit.warnings.length;
     }
-    return errorCount;
+    return { errors: errorCount, warnings: warningCount };
 };
 const setConfiguration = async (dataSource) => {
     (0, assert_1.default)(github.context.payload.pull_request);
@@ -41212,26 +41406,33 @@ async function run() {
         // Gathering commit message information
         const resultCommits = (0, validator_1.validateCommits)(commits);
         let errorCount = 0;
+        let warningCount = 0;
         const allResults = [...resultCommits];
         if (config.includePullRequest === true) {
             core.startGroup(`🔎 Scanning Pull Request`);
-            const resultPullrequest = (0, validator_1.validatePullRequest)({
+            const resultPullrequest = (0, validator_1.validatePullRequest)(commit_it_1.Commit.fromString({
                 hash: `#${github.context.payload.pull_request.number}`,
-                subject: github.context.payload.pull_request.title,
-                body: github.context.payload.pull_request.body ?? "",
-            }, resultCommits.map(commit => commit.commit).filter(commit => commit !== undefined));
+                message: [github.context.payload.pull_request.title, "", github.context.payload.pull_request.body].join("\n"),
+            }), allResults);
             allResults.push(resultPullrequest);
-            errorCount += reportErrorMessages([resultPullrequest]);
+            const counts = reportErrorMessages([resultPullrequest]);
+            errorCount += counts.errors;
+            warningCount += counts.warnings;
             core.endGroup();
         }
         if (config.includeCommits === true) {
             core.startGroup("🔎 Scanning Commits associated with Pull Request");
-            errorCount += reportErrorMessages(resultCommits);
+            const counts = reportErrorMessages(resultCommits);
+            errorCount += counts.errors;
+            warningCount += counts.warnings;
             core.endGroup();
         }
         if (errorCount > 0) {
-            core.setFailed(`❌ Found ${errorCount} Conventional Commits compliance issues.`);
+            core.setFailed(`❌ Found ${errorCount} Conventional Commit compliance issues, and ${warningCount} warnings.`);
             return;
+        }
+        else if (warningCount > 0) {
+            core.warning(`⚠️ Found ${warningCount} Conventional Commit compliance warnings.`);
         }
         // Updating the pull request label
         if (githubToken === undefined) {
@@ -41408,16 +41609,7 @@ const configuration_1 = __nccwpck_require__(5778);
  * @returns Validation result
  */
 function validateCommit(commit) {
-    const result = { commit: commit, errors: [] };
-    try {
-        result.commit = (0, commit_it_1.getConventionalCommit)(commit, configuration_1.Configuration.getInstance());
-    }
-    catch (error) {
-        if (!(error instanceof commit_it_1.ConventionalCommitError))
-            throw error;
-        error.errors.forEach(e => result.errors.push(e.toString()));
-    }
-    return result;
+    return commit_it_1.ConventionalCommit.fromCommit(commit, configuration_1.Configuration.getInstance());
 }
 /**
  * Validates the pull request against CommitMe requirements.
@@ -41427,27 +41619,28 @@ function validateCommit(commit) {
  */
 function validatePullRequest(pullrequest, commits) {
     const result = validateCommit(pullrequest);
-    if (result.errors.length > 0)
+    if (!result.isValid)
         return result;
     const orderValue = (commit) => {
-        if (!commit || !("type" in commit))
-            return 0;
         if (commit.breaking)
             return 3;
-        if (commit.type === "feat")
+        if (commit.type?.toLowerCase() === "feat")
             return 2;
-        if (commit.type === "fix")
+        if (commit.type?.toLowerCase() === "fix")
             return 1;
         return 0;
     };
-    const pullRequestValue = orderValue(result.commit);
-    const commitsValue = orderValue(commits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
+    const pullRequestValue = orderValue(result);
+    const validConventionalCommits = commits.filter(commit => commit.isValid);
+    const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
-        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.commit.hash, {
+        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
             text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
-        }).toString());
+        })
+            .setContext(1, result.subject)
+            .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: result.type?.length ?? 1 })));
     }
     return result;
 }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2094,9 +2094,9 @@ function isLoopbackAddress(host) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2121,8 +2121,75 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommit = exports.isConventionalCommit = exports.parseCommitMessage = void 0;
+exports.parseCommitMessage = exports.getFooterElementsFromParagraph = exports.Commit = void 0;
 const git = __importStar(__nccwpck_require__(8433));
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
+/**
+ * Git Commit
+ * @class Commit
+ * @member author The commit author and date
+ * @member commiter The commit commiter and date
+ * @member hash The commit hash
+ * @member subject The commit subject
+ * @member body The commit body
+ * @member footer The commit footer
+ * @member raw The commit message
+ */
+class Commit {
+    _commit;
+    constructor(commit) {
+        this._commit = commit;
+    }
+    /**
+     * Retrieves the commit information from git using the provided hash
+     * @param props The commit hash and root path
+     * @returns The commit object
+     */
+    static fromHash(props) {
+        const commit = git.getCommitFromHash(props.hash, props.rootPath ?? process.cwd());
+        return new Commit(commit);
+    }
+    /**
+     * Creates a Commit object from the provided string
+     * @param props The commit hash, author, committer and message
+     * @returns The commit object
+     */
+    static fromString(props) {
+        const commit = {
+            hash: props.hash,
+            ...parseCommitMessage(props.message),
+            author: props.author,
+            committer: props.committer,
+            raw: props.message,
+        };
+        return new Commit(commit);
+    }
+    get author() {
+        return this._commit.author;
+    }
+    get committer() {
+        return this._commit.committer;
+    }
+    get hash() {
+        return this._commit.hash;
+    }
+    get subject() {
+        return this._commit.subject;
+    }
+    get body() {
+        return this._commit.body;
+    }
+    get footer() {
+        return this._commit.footer;
+    }
+    get raw() {
+        return this._commit.raw;
+    }
+    toJSON() {
+        return this._commit;
+    }
+}
+exports.Commit = Commit;
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -2132,13 +2199,15 @@ const git = __importStar(__nccwpck_require__(8433));
  * The value is either:
  * - the remainder of the line
  * - the remainder of the line + anything that follows on the next lines which is indented by at least one space
+ *
+ * @internal
  */
-function parseCommitFooter(footer) {
-    const footerLines = footer.split(/[\r\n]+/);
-    const result = {};
+function getFooterElementsFromParagraph(footer) {
+    const footerLines = footer.split(/\r?\n/);
+    const result = [];
     for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
         const line = footerLines[lineNr];
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+        const match = TRAILER_REGEX.exec(line);
         if (match === null)
             continue;
         let key = match[1].replace(/:$/, "");
@@ -2147,15 +2216,22 @@ function parseCommitFooter(footer) {
             key = match[1].substring(0, match[1].length - 2);
             value = `#${value}`;
         }
+        const matchLine = lineNr;
         // Check if the value continues on the next line
-        while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+        while (lineNr + 1 < footerLines.length &&
+            (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)) {
             lineNr++;
             value += "\n" + footerLines[lineNr].trim();
         }
-        result[key] = value;
+        result.push({
+            lineNumber: matchLine + 1,
+            key,
+            value,
+        });
     }
     return Object.keys(result).length > 0 ? result : undefined;
 }
+exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
@@ -2164,11 +2240,11 @@ function parseCommitFooter(footer) {
  * @internal
  */
 function parseCommitMessage(message) {
-    const isTrailerOnly = (message) => message.split(/[\r\n]+/).every(line => {
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const isTrailerOnly = (message) => message.split(/\r?\n/).every(line => {
+        const match = TRAILER_REGEX.exec(line);
         return match !== null;
     });
-    const paragraphs = message.split(/^[\r\n]+/m);
+    const paragraphs = message.split(/^\r?\n/m);
     let footer = undefined;
     let body = undefined;
     if (paragraphs.length > 1 && isTrailerOnly(paragraphs[paragraphs.length - 1])) {
@@ -2183,69 +2259,26 @@ function parseCommitMessage(message) {
     return {
         subject: paragraphs[0].trim(),
         body: body,
-        footer: parseCommitFooter(footer !== null && footer !== void 0 ? footer : ""),
+        footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
+            acc[cur.key] = cur.value;
+            return acc;
+        }, {}),
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
-/**
- * Confirms whether the provided commit is a Conventional Commit
- * @param commit
- * @returns
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Retrieves the commit message (from the indicated source) given the provided SHA hash
- * @param hash SHA of the commit
- * @param source The data source to retrieve the commit message from (git or github)
- * @param options The options to use when retrieving the commit message
- * @returns Commit object
- */
-function getCommit(options) {
-    var _a;
-    let commit;
-    // String data source
-    if ("message" in options) {
-        const stringOptions = options;
-        commit = {
-            hash: stringOptions.hash,
-            ...parseCommitMessage(stringOptions.message),
-            author: stringOptions.author,
-            committer: stringOptions.committer,
-        };
-        // GitHub data source
-    }
-    else if ("owner" in options) {
-        const githubOptions = options;
-        // TODO; implement basic GitHub client
-        commit = {
-            hash: githubOptions.hash,
-            subject: "",
-        };
-        // Git data source
-    }
-    else {
-        const gitOptions = options;
-        commit = git.getCommitFromHash(gitOptions.hash, (_a = gitOptions.rootPath) !== null && _a !== void 0 ? _a : process.cwd());
-    }
-    return commit;
-}
-exports.getCommit = getCommit;
 
 
 /***/ }),
 
-/***/ 8436:
+/***/ 1124:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2269,101 +2302,162 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConventionalCommit = exports.isConventionalCommit = exports.ConventionalCommitError = void 0;
-const assert_1 = __importDefault(__nccwpck_require__(9491));
+exports.ConventionalCommit = void 0;
+const diagnose_it_1 = __nccwpck_require__(4657);
+const commit_1 = __nccwpck_require__(8065);
 const requirements = __importStar(__nccwpck_require__(4374));
 /**
- * Conventional Commit error
- * @class ConventionalCommitError
- * @extends Error
+ * Conventional Commit
+ * @class ConventionalCommit
+ * @member type Conventional Commit type
+ * @member scope Conventional Commit scope
+ * @member breaking Commit message has a Conventional Commit breaking change (!)
+ * @member description Conventional Commit description
+ * @member hash Commit hash
+ * @member subject Commit subject
+ * @member body Commit body
+ * @member footer Commit footer
+ * @member author Commit author and date
+ * @member committer Commit committer and date
+ * @member isValid Whether the Conventional Commit is valid
  * @member errors List of error messages
+ * @member warnings List of warning messages
  */
-class ConventionalCommitError extends Error {
-    constructor(errors) {
-        super("Commit is not compliant with the Conventional Commits specification.");
-        this.name = "ConventionalCommitError";
-        this.errors = errors;
+class ConventionalCommit {
+    _raw;
+    _errors = [];
+    _warnings = [];
+    constructor(raw, options) {
+        this._raw = raw;
+        this.validate(options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided Commit.
+     * @param commit Commit to convert to a Conventional Commit
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromCommit(commit, options) {
+        // Convert the Commit message to Raw Conventional Commit data
+        const rawConvCommit = createRawConventionalCommit(commit);
+        // Create a new Conventional Commit object
+        return new ConventionalCommit(rawConvCommit, options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided string.
+     * @param props Hash, message and author/committer information
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromString(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromString(props), options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided hash.
+     * @param props Hash and root path
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromHash(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromHash(props), options);
+    }
+    // Contributors
+    get author() {
+        return this._raw.commit.author;
+    }
+    get committer() {
+        return this._raw.commit.committer;
+    }
+    // Commit
+    get hash() {
+        return this._raw.commit.hash;
+    }
+    get subject() {
+        return this._raw.commit.subject;
+    }
+    get body() {
+        return this._raw.commit.body;
+    }
+    get footer() {
+        return this._raw.commit.footer;
+    }
+    // Conventional Commit
+    get type() {
+        return this._raw.type.value;
+    }
+    get scope() {
+        return this._raw.scope.value;
+    }
+    get description() {
+        return this._raw.description.value;
+    }
+    get breaking() {
+        return (this._raw.breaking.value === "!" ||
+            (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
+    }
+    // Raw
+    get raw() {
+        return this._raw.commit.raw;
+    }
+    // Validation
+    get isValid() {
+        return this._errors.length === 0;
+    }
+    get warnings() {
+        return this._warnings;
+    }
+    get errors() {
+        return this._errors;
+    }
+    toJSON() {
+        return {
+            hash: this.hash,
+            author: this.author,
+            committer: this.committer,
+            subject: this.subject,
+            body: this.body,
+            footer: this.footer,
+            type: this.type,
+            breaking: this.breaking,
+            description: this.description,
+            validation: {
+                isValid: this.isValid,
+                errors: this.errors,
+                warnings: this.warnings,
+            },
+        };
+    }
+    // Private validation function
+    validate(options) {
+        let results = [];
+        requirements.commitRules.forEach(rule => (results = [...results, ...rule.validate(this._raw, options)]));
+        this._errors = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Error);
+        this._warnings = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Warning);
     }
 }
-exports.ConventionalCommitError = ConventionalCommitError;
-/**
- * Returns whether the provided commit has a breaking change (either "!" in subject, or usage of /BREAKING[- ]CHANGE:/).
- * @param commit Commit to check
- * @returns Whether the provided commit has a breaking change
- */
-function hasBreakingChange(commit) {
-    return (commit.breaking.value === "!" ||
-        (commit.commit.footer !== undefined &&
-            ("BREAKING CHANGE" in commit.commit.footer || "BREAKING-CHANGE" in commit.commit.footer)));
-}
-/**
- * Validates a commit message against the Conventional Commit specification.
- * @param commit Commit message to validate against the Conventional Commit specification
- * @returns Conventional Commit mesage
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @see https://www.conventionalcommits.org/en/v1.0.0/
- */
-function validate(commit, options) {
-    let errors = [];
-    requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
-    if (errors.length > 0)
-        throw new ConventionalCommitError(errors);
-    // Assume that we have a valid Conventional Commit message
-    (0, assert_1.default)(commit.type.value);
-    (0, assert_1.default)(commit.description.value);
-    return {
-        ...commit.commit,
-        type: commit.type.value,
-        scope: commit.scope.value,
-        breaking: hasBreakingChange(commit),
-        description: commit.description.value,
-    };
-}
-/**
- * Returns whether the provided commit is a Conventional Commit.
- * @param commit Commit to check
- * @returns Whether the provided commit is a Conventional Commit
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Parses a Commit message into a Conventional Commit.
- * @param commit Commit message to parse
- * @param options Options to use when parsing the commit message
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @returns Conventional Commit
- */
-function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e;
+exports.ConventionalCommit = ConventionalCommit;
+function createRawConventionalCommit(commit) {
     const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
-    const match = ConventionalCommitRegex.exec(commit.subject);
-    let conventionalCommit = {
+    const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
+    const conventionalCommit = {
         commit: commit,
-        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
+        type: { index: 1, value: match?.groups?.type },
+        scope: { index: 1, value: match?.groups?.scope },
+        breaking: { index: 1, value: match?.groups?.breaking },
+        seperator: { index: 1, value: match?.groups?.separator },
+        description: { index: 1, value: match?.groups?.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
-        commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
-        commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
-        commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
+        commit.scope.index = commit.type.index + (commit.type.value?.length ?? 0);
+        commit.breaking.index = commit.scope.index + (commit.scope.value?.length ?? 0);
+        commit.seperator.index = commit.breaking.index + (commit.breaking.value?.length ?? 0);
+        commit.description.index = commit.seperator.index + (commit.seperator.value?.length ?? 0);
         return commit;
     }
-    conventionalCommit = intializeIndices(conventionalCommit);
-    return validate(conventionalCommit, options);
+    return intializeIndices(conventionalCommit);
 }
-exports.getConventionalCommit = getConventionalCommit;
 
 
 /***/ }),
@@ -2374,9 +2468,9 @@ exports.getConventionalCommit = getConventionalCommit;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2456,15 +2550,17 @@ function getValueFromKey(commit, key) {
 function parseCommitMessage(commit, hash) {
     const author = extractNameAndDate(getValueFromKey(commit, "author"));
     const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+    const raw = commit
+        .split(/^[\r\n]+/m)
+        .splice(1)
+        .join("\n")
+        .trim();
     return {
+        raw,
         hash: hash,
         author: author,
         committer: committer,
-        ...ccommit.parseCommitMessage(commit
-            .split(/^[\r\n]+/m)
-            .splice(1)
-            .join("\n")
-            .trim()),
+        ...ccommit.parseCommitMessage(raw),
     };
 }
 /**
@@ -2606,17 +2702,15 @@ function readPackFile(path, index) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ConventionalCommitError = exports.isConventionalCommit = exports.getConventionalCommit = exports.getCommit = void 0;
+exports.ConventionalCommit = exports.Commit = void 0;
 var commit_1 = __nccwpck_require__(8065);
-Object.defineProperty(exports, "getCommit", ({ enumerable: true, get: function () { return commit_1.getCommit; } }));
-var conventional_commit_1 = __nccwpck_require__(8436);
-Object.defineProperty(exports, "getConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.getConventionalCommit; } }));
-Object.defineProperty(exports, "isConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.isConventionalCommit; } }));
-Object.defineProperty(exports, "ConventionalCommitError", ({ enumerable: true, get: function () { return conventional_commit_1.ConventionalCommitError; } }));
+Object.defineProperty(exports, "Commit", ({ enumerable: true, get: function () { return commit_1.Commit; } }));
+var conventionalCommit_1 = __nccwpck_require__(1124);
+Object.defineProperty(exports, "ConventionalCommit", ({ enumerable: true, get: function () { return conventionalCommit_1.ConventionalCommit; } }));
 
 
 /***/ }),
@@ -2632,13 +2726,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitRules = void 0;
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: CC-BY-3.0
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: CC-BY-3.0
+ */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+const commit_1 = __nccwpck_require__(8065);
 function isNoun(str) {
     return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
 }
@@ -2651,29 +2746,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type, whitespace = false) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+function createDiagnosticsMessage(commit, description, highlight, type, whitespace = false, level = diagnose_it_1.DiagnosticsLevelEnum.Error) {
     const element = commit[type];
     let hintIndex = element.index;
-    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    let hintLength = element.value?.trimEnd().length ?? 1;
     if (whitespace) {
         let prevElement = undefined;
         for (const [_key, value] of Object.entries(commit)) {
-            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+            if (value.index > (prevElement?.index ?? 0) && value.index < element.index) {
                 prevElement = value;
             }
         }
-        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
-        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+        hintIndex = prevElement ? prevElement.index + (prevElement.value?.trimEnd().length ?? 1) : 1;
+        hintLength = (prevElement?.value?.length ?? 1) - (prevElement?.value?.trimEnd().length ?? 1);
     }
-    return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
-        text: highlightString(description, highlight),
-        linenumber: 1,
-        column: hintIndex,
+    return new diagnose_it_1.DiagnosticsMessage({
+        file: commit.commit.hash,
+        level,
+        message: {
+            text: highlightString(description, highlight),
+            linenumber: 1,
+            column: hintIndex,
+        },
     })
-        .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
-        ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
-        : [commit.commit.subject])
+        .setContext(1, commit.commit.subject.split(/\r?\n/)[0])
         .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
@@ -2681,10 +2777,8 @@ function createError(commit, description, highlight, type, whitespace = false) {
  * followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
  */
 class CC01 {
-    constructor() {
-        this.id = "CC-01";
-        this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
-    }
+    id = "CC-01";
+    description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
@@ -2694,29 +2788,36 @@ class CC01 {
         else {
             // Ensure that we have a noun
             if (!isNoun(commit.type.value))
-                errors.push(createError(commit, this.description, "which consists of a noun", "type"));
+                errors.push(createDiagnosticsMessage(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
-                if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
-                else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.scope.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
+                }
+                else if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
             // Validate for spacing after the scope, breaking and seperator
             if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
-                if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
-            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value) {
+                errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
         }
         // MUST have a terminal colon
-        if (!commit.seperator.value)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        if (!commit.seperator.value) {
+            errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        }
         return errors;
     }
 }
@@ -2725,16 +2826,14 @@ class CC01 {
  * a section of the codebase surrounded by parenthesis, e.g., fix(parser):
  */
 class CC04 {
-    constructor() {
-        this.id = "CC-04";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
-    }
+    id = "CC-04";
+    description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
             (commit.scope.value === "()" ||
                 !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
-            errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
+            errors.push(createDiagnosticsMessage(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
     }
@@ -2745,17 +2844,73 @@ class CC04 {
  * when multiple spaces were contained in string.
  */
 class CC05 {
-    constructor() {
-        this.id = "CC-05";
-        this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
-    }
+    id = "CC-05";
+    description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     validate(commit, _options) {
         const errors = [];
-        if (!commit.seperator.value)
+        if (!commit.seperator.value) {
             return errors;
+        }
         if (commit.description.value === undefined ||
-            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1) {
+            errors.push(createDiagnosticsMessage(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+        }
+        return errors;
+    }
+}
+/**
+ * A longer commit body MAY be provided after the short description, providing
+ * additional contextual information about the code changes. The body MUST begin one
+ * blank line after the description.
+ */
+class CC06 {
+    id = "CC-06";
+    description = "A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.";
+    validate(commit, _options) {
+        const errors = [];
+        if (!commit.commit.subject) {
+            return errors;
+        }
+        const lines = commit.commit.subject.split(/\r?\n/);
+        if (lines.length > 1) {
+            return [
+                diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                    text: highlightString(this.description, "The body MUST begin one blank line after the description"),
+                    linenumber: 2,
+                    column: 1,
+                })
+                    .setContext(1, lines)
+                    .addFixitHint(diagnose_it_1.FixItHint.createRemoval({ index: 1, length: lines[1].length })),
+            ];
+        }
+        return errors;
+    }
+}
+/**
+ * The units of information that make up Conventional Commits MUST NOT be treated as case
+ * sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+ */
+class CC15 {
+    id = "CC-15";
+    description = "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.";
+    validate(commit, _options) {
+        const errors = [];
+        const footerElements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.raw);
+        if (footerElements === undefined)
+            return errors;
+        for (const element of footerElements) {
+            if (["BREAKING CHANGE", "BREAKING-CHANGE"].includes(element.key.toUpperCase())) {
+                if (element.key !== element.key.toUpperCase()) {
+                    errors.push(diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                        text: highlightString(this.description, "BREAKING CHANGE MUST be uppercase"),
+                        linenumber: element.lineNumber,
+                        column: 1,
+                    })
+                        .setContext(element.lineNumber, commit.commit.raw.split(/\r?\n/)[element.lineNumber - 1])
+                        .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+                }
+            }
+        }
         return errors;
     }
 }
@@ -2763,20 +2918,19 @@ class CC05 {
  * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
-    constructor() {
-        this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
-    }
+    id = "EC-01";
+    description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     validate(commit, options) {
-        var _a;
-        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
-        if (uniqueScopeList.length === 0)
+        const uniqueScopeList = Array.from(new Set(options?.scopes ?? []));
+        if (uniqueScopeList.length === 0) {
             return [];
-        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
+        }
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, ""))) {
             return [];
+        }
         this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
+            createDiagnosticsMessage(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
@@ -2784,33 +2938,74 @@ class EC01 {
  * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
-    constructor() {
-        this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
-    }
+    id = "EC-02";
+    description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     validate(commit, options) {
-        var _a;
-        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        const uniqueAddedTypes = new Set(options?.types ?? []);
         if (uniqueAddedTypes.has("feat"))
             uniqueAddedTypes.delete("feat");
         if (uniqueAddedTypes.has("fix"))
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        this.description = `Commits ${uniqueAddedTypes.size > 0 ? "MUST" : "MAY"} be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
         if (commit.type.value === undefined ||
             !isNoun(commit.type.value) ||
-            expectedTypes.includes(commit.type.value.trimEnd()))
+            expectedTypes.includes(commit.type.value.toLowerCase().trimEnd())) {
             return [];
-        if (commit.type.value.trim().length === 0) {
-            return [createError(commit, this.description, "prefixed with a type", "type")];
         }
-        return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
-        ];
+        if (commit.type.value.trim().length === 0) {
+            return [createDiagnosticsMessage(commit, this.description, "prefixed with a type", "type")];
+        }
+        if (uniqueAddedTypes.size > 0) {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
+            ];
+        }
+        else {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type", false, diagnose_it_1.DiagnosticsLevelEnum.Warning),
+            ];
+        }
+    }
+}
+/**
+ * A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.
+ */
+class WA01 {
+    id = "WA-01";
+    description = "A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.";
+    validate(commit, _options) {
+        const errors = [];
+        if (commit.commit.body === undefined)
+            return errors;
+        const elements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.body);
+        if (elements === undefined)
+            return errors;
+        for (const element of elements) {
+            if (element.key === "BREAKING CHANGE" || element.key === "BREAKING-CHANGE") {
+                errors.push(diagnose_it_1.DiagnosticsMessage.createWarning(commit.commit.hash, {
+                    text: highlightString(`A \`${element.key}\` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.`, [element.key, "will be ignored as it MUST be included in the footer"]),
+                    linenumber: commit.commit.subject.split(/\r?\n/).length + element.lineNumber,
+                    column: 1,
+                })
+                    .setContext(commit.commit.subject.split(/\r?\n/).length + 1, commit.commit.body.split(/\r?\n/))
+                    .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+            }
+        }
+        return errors;
     }
 }
 /** @internal */
-exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
+exports.commitRules = [
+    new CC01(),
+    new CC04(),
+    new CC05(),
+    new CC06(),
+    new CC15(),
+    new EC01(),
+    new EC02(),
+    new WA01(),
+];
 
 
 /***/ }),
@@ -41012,7 +41207,7 @@ class FileSource {
         }
     }
     async getCommitMessages() {
-        return [(0, commit_it_1.getCommit)({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
+        return [commit_it_1.Commit.fromString({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41032,7 +41227,7 @@ class GitSource {
     }
     async getCommitMessages() {
         const data = await (0, simple_git_1.simpleGit)().log({ from: this.sourceBranch, to: "@{push}" });
-        return data.all.map(commit => (0, commit_it_1.getCommit)({ hash: commit.hash }));
+        return data.all.map(commit => commit_it_1.Commit.fromHash({ hash: commit.hash }));
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41051,13 +41246,10 @@ class GitHubSource {
         const pullRequestNumber = github.context.payload.pull_request?.number;
         (0, assert_1.default)(pullRequestNumber);
         const commits = await octokit.rest.pulls.listCommits({ ...github.context.repo, pull_number: pullRequestNumber });
-        return commits.data.map(commit => {
-            return {
-                hash: commit.sha,
-                subject: commit.commit.message.split(/\r?\n/)[0],
-                body: commit.commit.message.split(/\r?\n/).slice(2).join("\n"),
-            };
-        });
+        return commits.data.map(commit => commit_it_1.Commit.fromString({
+            hash: commit.sha,
+            message: commit.commit.message,
+        }));
     }
     /**
      * Retrieves the specified configuration file from the repository using the REST API
@@ -41133,18 +41325,21 @@ program
     config.addTypes(options.types ?? []);
     const commits = await datasource.getCommitMessages();
     let errorCount = 0;
+    let warningCount = 0;
     const results = (0, validator_1.validateCommits)(commits);
     for (const commit of results) {
-        console.log(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.subject.substring(0, 77)}${commit.commit.subject.length > 80 ? "..." : ""}`);
-        commit.errors.forEach(error => console.log(error, os_1.default.EOL));
+        console.log(`${commit.errors.length === 0 ? "✅" : "❌"} ${commit.hash}: ${commit.subject.substring(0, 77)}${commit.subject.length > 80 ? "..." : ""}`);
+        commit.errors.forEach(err => console.log(err.toString(), os_1.default.EOL));
+        commit.warnings.forEach(err => console.log(err.toString(), os_1.default.EOL));
         errorCount += commit.errors.length;
+        warningCount += commit.warnings.length;
     }
     console.log("-------------------------------------------------------");
     if (errorCount === 0) {
         console.log(`✅ All your commits are compliant with Conventional Commit.`);
     }
     else {
-        program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+        program.error(`❌ Found ${errorCount} Conventional Commit compliance issues, and ${warningCount} warnings.`);
     }
 });
 program.parse(process.argv);
@@ -41172,16 +41367,7 @@ const configuration_1 = __nccwpck_require__(5778);
  * @returns Validation result
  */
 function validateCommit(commit) {
-    const result = { commit: commit, errors: [] };
-    try {
-        result.commit = (0, commit_it_1.getConventionalCommit)(commit, configuration_1.Configuration.getInstance());
-    }
-    catch (error) {
-        if (!(error instanceof commit_it_1.ConventionalCommitError))
-            throw error;
-        error.errors.forEach(e => result.errors.push(e.toString()));
-    }
-    return result;
+    return commit_it_1.ConventionalCommit.fromCommit(commit, configuration_1.Configuration.getInstance());
 }
 /**
  * Validates the pull request against CommitMe requirements.
@@ -41191,27 +41377,28 @@ function validateCommit(commit) {
  */
 function validatePullRequest(pullrequest, commits) {
     const result = validateCommit(pullrequest);
-    if (result.errors.length > 0)
+    if (!result.isValid)
         return result;
     const orderValue = (commit) => {
-        if (!commit || !("type" in commit))
-            return 0;
         if (commit.breaking)
             return 3;
-        if (commit.type === "feat")
+        if (commit.type?.toLowerCase() === "feat")
             return 2;
-        if (commit.type === "fix")
+        if (commit.type?.toLowerCase() === "fix")
             return 1;
         return 0;
     };
-    const pullRequestValue = orderValue(result.commit);
-    const commitsValue = orderValue(commits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
+    const pullRequestValue = orderValue(result);
+    const validConventionalCommits = commits.filter(commit => commit.isValid);
+    const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
-        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.commit.hash, {
+        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
             text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
-        }).toString());
+        })
+            .setContext(1, result.subject)
+            .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: result.type?.length ?? 1 })));
     }
     return result;
 }

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -2094,9 +2094,9 @@ function isLoopbackAddress(host) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2121,8 +2121,75 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommit = exports.isConventionalCommit = exports.parseCommitMessage = void 0;
+exports.parseCommitMessage = exports.getFooterElementsFromParagraph = exports.Commit = void 0;
 const git = __importStar(__nccwpck_require__(8433));
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
+/**
+ * Git Commit
+ * @class Commit
+ * @member author The commit author and date
+ * @member commiter The commit commiter and date
+ * @member hash The commit hash
+ * @member subject The commit subject
+ * @member body The commit body
+ * @member footer The commit footer
+ * @member raw The commit message
+ */
+class Commit {
+    _commit;
+    constructor(commit) {
+        this._commit = commit;
+    }
+    /**
+     * Retrieves the commit information from git using the provided hash
+     * @param props The commit hash and root path
+     * @returns The commit object
+     */
+    static fromHash(props) {
+        const commit = git.getCommitFromHash(props.hash, props.rootPath ?? process.cwd());
+        return new Commit(commit);
+    }
+    /**
+     * Creates a Commit object from the provided string
+     * @param props The commit hash, author, committer and message
+     * @returns The commit object
+     */
+    static fromString(props) {
+        const commit = {
+            hash: props.hash,
+            ...parseCommitMessage(props.message),
+            author: props.author,
+            committer: props.committer,
+            raw: props.message,
+        };
+        return new Commit(commit);
+    }
+    get author() {
+        return this._commit.author;
+    }
+    get committer() {
+        return this._commit.committer;
+    }
+    get hash() {
+        return this._commit.hash;
+    }
+    get subject() {
+        return this._commit.subject;
+    }
+    get body() {
+        return this._commit.body;
+    }
+    get footer() {
+        return this._commit.footer;
+    }
+    get raw() {
+        return this._commit.raw;
+    }
+    toJSON() {
+        return this._commit;
+    }
+}
+exports.Commit = Commit;
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -2132,13 +2199,15 @@ const git = __importStar(__nccwpck_require__(8433));
  * The value is either:
  * - the remainder of the line
  * - the remainder of the line + anything that follows on the next lines which is indented by at least one space
+ *
+ * @internal
  */
-function parseCommitFooter(footer) {
-    const footerLines = footer.split(/[\r\n]+/);
-    const result = {};
+function getFooterElementsFromParagraph(footer) {
+    const footerLines = footer.split(/\r?\n/);
+    const result = [];
     for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
         const line = footerLines[lineNr];
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+        const match = TRAILER_REGEX.exec(line);
         if (match === null)
             continue;
         let key = match[1].replace(/:$/, "");
@@ -2147,15 +2216,22 @@ function parseCommitFooter(footer) {
             key = match[1].substring(0, match[1].length - 2);
             value = `#${value}`;
         }
+        const matchLine = lineNr;
         // Check if the value continues on the next line
-        while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+        while (lineNr + 1 < footerLines.length &&
+            (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)) {
             lineNr++;
             value += "\n" + footerLines[lineNr].trim();
         }
-        result[key] = value;
+        result.push({
+            lineNumber: matchLine + 1,
+            key,
+            value,
+        });
     }
     return Object.keys(result).length > 0 ? result : undefined;
 }
+exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
@@ -2164,11 +2240,11 @@ function parseCommitFooter(footer) {
  * @internal
  */
 function parseCommitMessage(message) {
-    const isTrailerOnly = (message) => message.split(/[\r\n]+/).every(line => {
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const isTrailerOnly = (message) => message.split(/\r?\n/).every(line => {
+        const match = TRAILER_REGEX.exec(line);
         return match !== null;
     });
-    const paragraphs = message.split(/^[\r\n]+/m);
+    const paragraphs = message.split(/^\r?\n/m);
     let footer = undefined;
     let body = undefined;
     if (paragraphs.length > 1 && isTrailerOnly(paragraphs[paragraphs.length - 1])) {
@@ -2183,69 +2259,26 @@ function parseCommitMessage(message) {
     return {
         subject: paragraphs[0].trim(),
         body: body,
-        footer: parseCommitFooter(footer !== null && footer !== void 0 ? footer : ""),
+        footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
+            acc[cur.key] = cur.value;
+            return acc;
+        }, {}),
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
-/**
- * Confirms whether the provided commit is a Conventional Commit
- * @param commit
- * @returns
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Retrieves the commit message (from the indicated source) given the provided SHA hash
- * @param hash SHA of the commit
- * @param source The data source to retrieve the commit message from (git or github)
- * @param options The options to use when retrieving the commit message
- * @returns Commit object
- */
-function getCommit(options) {
-    var _a;
-    let commit;
-    // String data source
-    if ("message" in options) {
-        const stringOptions = options;
-        commit = {
-            hash: stringOptions.hash,
-            ...parseCommitMessage(stringOptions.message),
-            author: stringOptions.author,
-            committer: stringOptions.committer,
-        };
-        // GitHub data source
-    }
-    else if ("owner" in options) {
-        const githubOptions = options;
-        // TODO; implement basic GitHub client
-        commit = {
-            hash: githubOptions.hash,
-            subject: "",
-        };
-        // Git data source
-    }
-    else {
-        const gitOptions = options;
-        commit = git.getCommitFromHash(gitOptions.hash, (_a = gitOptions.rootPath) !== null && _a !== void 0 ? _a : process.cwd());
-    }
-    return commit;
-}
-exports.getCommit = getCommit;
 
 
 /***/ }),
 
-/***/ 8436:
+/***/ 1124:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2269,101 +2302,162 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConventionalCommit = exports.isConventionalCommit = exports.ConventionalCommitError = void 0;
-const assert_1 = __importDefault(__nccwpck_require__(9491));
+exports.ConventionalCommit = void 0;
+const diagnose_it_1 = __nccwpck_require__(4657);
+const commit_1 = __nccwpck_require__(8065);
 const requirements = __importStar(__nccwpck_require__(4374));
 /**
- * Conventional Commit error
- * @class ConventionalCommitError
- * @extends Error
+ * Conventional Commit
+ * @class ConventionalCommit
+ * @member type Conventional Commit type
+ * @member scope Conventional Commit scope
+ * @member breaking Commit message has a Conventional Commit breaking change (!)
+ * @member description Conventional Commit description
+ * @member hash Commit hash
+ * @member subject Commit subject
+ * @member body Commit body
+ * @member footer Commit footer
+ * @member author Commit author and date
+ * @member committer Commit committer and date
+ * @member isValid Whether the Conventional Commit is valid
  * @member errors List of error messages
+ * @member warnings List of warning messages
  */
-class ConventionalCommitError extends Error {
-    constructor(errors) {
-        super("Commit is not compliant with the Conventional Commits specification.");
-        this.name = "ConventionalCommitError";
-        this.errors = errors;
+class ConventionalCommit {
+    _raw;
+    _errors = [];
+    _warnings = [];
+    constructor(raw, options) {
+        this._raw = raw;
+        this.validate(options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided Commit.
+     * @param commit Commit to convert to a Conventional Commit
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromCommit(commit, options) {
+        // Convert the Commit message to Raw Conventional Commit data
+        const rawConvCommit = createRawConventionalCommit(commit);
+        // Create a new Conventional Commit object
+        return new ConventionalCommit(rawConvCommit, options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided string.
+     * @param props Hash, message and author/committer information
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromString(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromString(props), options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided hash.
+     * @param props Hash and root path
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromHash(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromHash(props), options);
+    }
+    // Contributors
+    get author() {
+        return this._raw.commit.author;
+    }
+    get committer() {
+        return this._raw.commit.committer;
+    }
+    // Commit
+    get hash() {
+        return this._raw.commit.hash;
+    }
+    get subject() {
+        return this._raw.commit.subject;
+    }
+    get body() {
+        return this._raw.commit.body;
+    }
+    get footer() {
+        return this._raw.commit.footer;
+    }
+    // Conventional Commit
+    get type() {
+        return this._raw.type.value;
+    }
+    get scope() {
+        return this._raw.scope.value;
+    }
+    get description() {
+        return this._raw.description.value;
+    }
+    get breaking() {
+        return (this._raw.breaking.value === "!" ||
+            (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
+    }
+    // Raw
+    get raw() {
+        return this._raw.commit.raw;
+    }
+    // Validation
+    get isValid() {
+        return this._errors.length === 0;
+    }
+    get warnings() {
+        return this._warnings;
+    }
+    get errors() {
+        return this._errors;
+    }
+    toJSON() {
+        return {
+            hash: this.hash,
+            author: this.author,
+            committer: this.committer,
+            subject: this.subject,
+            body: this.body,
+            footer: this.footer,
+            type: this.type,
+            breaking: this.breaking,
+            description: this.description,
+            validation: {
+                isValid: this.isValid,
+                errors: this.errors,
+                warnings: this.warnings,
+            },
+        };
+    }
+    // Private validation function
+    validate(options) {
+        let results = [];
+        requirements.commitRules.forEach(rule => (results = [...results, ...rule.validate(this._raw, options)]));
+        this._errors = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Error);
+        this._warnings = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Warning);
     }
 }
-exports.ConventionalCommitError = ConventionalCommitError;
-/**
- * Returns whether the provided commit has a breaking change (either "!" in subject, or usage of /BREAKING[- ]CHANGE:/).
- * @param commit Commit to check
- * @returns Whether the provided commit has a breaking change
- */
-function hasBreakingChange(commit) {
-    return (commit.breaking.value === "!" ||
-        (commit.commit.footer !== undefined &&
-            ("BREAKING CHANGE" in commit.commit.footer || "BREAKING-CHANGE" in commit.commit.footer)));
-}
-/**
- * Validates a commit message against the Conventional Commit specification.
- * @param commit Commit message to validate against the Conventional Commit specification
- * @returns Conventional Commit mesage
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @see https://www.conventionalcommits.org/en/v1.0.0/
- */
-function validate(commit, options) {
-    let errors = [];
-    requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
-    if (errors.length > 0)
-        throw new ConventionalCommitError(errors);
-    // Assume that we have a valid Conventional Commit message
-    (0, assert_1.default)(commit.type.value);
-    (0, assert_1.default)(commit.description.value);
-    return {
-        ...commit.commit,
-        type: commit.type.value,
-        scope: commit.scope.value,
-        breaking: hasBreakingChange(commit),
-        description: commit.description.value,
-    };
-}
-/**
- * Returns whether the provided commit is a Conventional Commit.
- * @param commit Commit to check
- * @returns Whether the provided commit is a Conventional Commit
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Parses a Commit message into a Conventional Commit.
- * @param commit Commit message to parse
- * @param options Options to use when parsing the commit message
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @returns Conventional Commit
- */
-function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e;
+exports.ConventionalCommit = ConventionalCommit;
+function createRawConventionalCommit(commit) {
     const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
-    const match = ConventionalCommitRegex.exec(commit.subject);
-    let conventionalCommit = {
+    const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
+    const conventionalCommit = {
         commit: commit,
-        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
+        type: { index: 1, value: match?.groups?.type },
+        scope: { index: 1, value: match?.groups?.scope },
+        breaking: { index: 1, value: match?.groups?.breaking },
+        seperator: { index: 1, value: match?.groups?.separator },
+        description: { index: 1, value: match?.groups?.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
-        commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
-        commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
-        commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
+        commit.scope.index = commit.type.index + (commit.type.value?.length ?? 0);
+        commit.breaking.index = commit.scope.index + (commit.scope.value?.length ?? 0);
+        commit.seperator.index = commit.breaking.index + (commit.breaking.value?.length ?? 0);
+        commit.description.index = commit.seperator.index + (commit.seperator.value?.length ?? 0);
         return commit;
     }
-    conventionalCommit = intializeIndices(conventionalCommit);
-    return validate(conventionalCommit, options);
+    return intializeIndices(conventionalCommit);
 }
-exports.getConventionalCommit = getConventionalCommit;
 
 
 /***/ }),
@@ -2374,9 +2468,9 @@ exports.getConventionalCommit = getConventionalCommit;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2456,15 +2550,17 @@ function getValueFromKey(commit, key) {
 function parseCommitMessage(commit, hash) {
     const author = extractNameAndDate(getValueFromKey(commit, "author"));
     const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+    const raw = commit
+        .split(/^[\r\n]+/m)
+        .splice(1)
+        .join("\n")
+        .trim();
     return {
+        raw,
         hash: hash,
         author: author,
         committer: committer,
-        ...ccommit.parseCommitMessage(commit
-            .split(/^[\r\n]+/m)
-            .splice(1)
-            .join("\n")
-            .trim()),
+        ...ccommit.parseCommitMessage(raw),
     };
 }
 /**
@@ -2606,17 +2702,15 @@ function readPackFile(path, index) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ConventionalCommitError = exports.isConventionalCommit = exports.getConventionalCommit = exports.getCommit = void 0;
+exports.ConventionalCommit = exports.Commit = void 0;
 var commit_1 = __nccwpck_require__(8065);
-Object.defineProperty(exports, "getCommit", ({ enumerable: true, get: function () { return commit_1.getCommit; } }));
-var conventional_commit_1 = __nccwpck_require__(8436);
-Object.defineProperty(exports, "getConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.getConventionalCommit; } }));
-Object.defineProperty(exports, "isConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.isConventionalCommit; } }));
-Object.defineProperty(exports, "ConventionalCommitError", ({ enumerable: true, get: function () { return conventional_commit_1.ConventionalCommitError; } }));
+Object.defineProperty(exports, "Commit", ({ enumerable: true, get: function () { return commit_1.Commit; } }));
+var conventionalCommit_1 = __nccwpck_require__(1124);
+Object.defineProperty(exports, "ConventionalCommit", ({ enumerable: true, get: function () { return conventionalCommit_1.ConventionalCommit; } }));
 
 
 /***/ }),
@@ -2632,13 +2726,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitRules = void 0;
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: CC-BY-3.0
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: CC-BY-3.0
+ */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+const commit_1 = __nccwpck_require__(8065);
 function isNoun(str) {
     return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
 }
@@ -2651,29 +2746,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type, whitespace = false) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+function createDiagnosticsMessage(commit, description, highlight, type, whitespace = false, level = diagnose_it_1.DiagnosticsLevelEnum.Error) {
     const element = commit[type];
     let hintIndex = element.index;
-    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    let hintLength = element.value?.trimEnd().length ?? 1;
     if (whitespace) {
         let prevElement = undefined;
         for (const [_key, value] of Object.entries(commit)) {
-            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+            if (value.index > (prevElement?.index ?? 0) && value.index < element.index) {
                 prevElement = value;
             }
         }
-        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
-        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+        hintIndex = prevElement ? prevElement.index + (prevElement.value?.trimEnd().length ?? 1) : 1;
+        hintLength = (prevElement?.value?.length ?? 1) - (prevElement?.value?.trimEnd().length ?? 1);
     }
-    return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
-        text: highlightString(description, highlight),
-        linenumber: 1,
-        column: hintIndex,
+    return new diagnose_it_1.DiagnosticsMessage({
+        file: commit.commit.hash,
+        level,
+        message: {
+            text: highlightString(description, highlight),
+            linenumber: 1,
+            column: hintIndex,
+        },
     })
-        .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
-        ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
-        : [commit.commit.subject])
+        .setContext(1, commit.commit.subject.split(/\r?\n/)[0])
         .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
@@ -2681,10 +2777,8 @@ function createError(commit, description, highlight, type, whitespace = false) {
  * followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
  */
 class CC01 {
-    constructor() {
-        this.id = "CC-01";
-        this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
-    }
+    id = "CC-01";
+    description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
@@ -2694,29 +2788,36 @@ class CC01 {
         else {
             // Ensure that we have a noun
             if (!isNoun(commit.type.value))
-                errors.push(createError(commit, this.description, "which consists of a noun", "type"));
+                errors.push(createDiagnosticsMessage(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
-                if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
-                else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.scope.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
+                }
+                else if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
             // Validate for spacing after the scope, breaking and seperator
             if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
-                if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
-            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value) {
+                errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
         }
         // MUST have a terminal colon
-        if (!commit.seperator.value)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        if (!commit.seperator.value) {
+            errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        }
         return errors;
     }
 }
@@ -2725,16 +2826,14 @@ class CC01 {
  * a section of the codebase surrounded by parenthesis, e.g., fix(parser):
  */
 class CC04 {
-    constructor() {
-        this.id = "CC-04";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
-    }
+    id = "CC-04";
+    description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
             (commit.scope.value === "()" ||
                 !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
-            errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
+            errors.push(createDiagnosticsMessage(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
     }
@@ -2745,17 +2844,73 @@ class CC04 {
  * when multiple spaces were contained in string.
  */
 class CC05 {
-    constructor() {
-        this.id = "CC-05";
-        this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
-    }
+    id = "CC-05";
+    description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     validate(commit, _options) {
         const errors = [];
-        if (!commit.seperator.value)
+        if (!commit.seperator.value) {
             return errors;
+        }
         if (commit.description.value === undefined ||
-            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1) {
+            errors.push(createDiagnosticsMessage(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+        }
+        return errors;
+    }
+}
+/**
+ * A longer commit body MAY be provided after the short description, providing
+ * additional contextual information about the code changes. The body MUST begin one
+ * blank line after the description.
+ */
+class CC06 {
+    id = "CC-06";
+    description = "A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.";
+    validate(commit, _options) {
+        const errors = [];
+        if (!commit.commit.subject) {
+            return errors;
+        }
+        const lines = commit.commit.subject.split(/\r?\n/);
+        if (lines.length > 1) {
+            return [
+                diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                    text: highlightString(this.description, "The body MUST begin one blank line after the description"),
+                    linenumber: 2,
+                    column: 1,
+                })
+                    .setContext(1, lines)
+                    .addFixitHint(diagnose_it_1.FixItHint.createRemoval({ index: 1, length: lines[1].length })),
+            ];
+        }
+        return errors;
+    }
+}
+/**
+ * The units of information that make up Conventional Commits MUST NOT be treated as case
+ * sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+ */
+class CC15 {
+    id = "CC-15";
+    description = "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.";
+    validate(commit, _options) {
+        const errors = [];
+        const footerElements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.raw);
+        if (footerElements === undefined)
+            return errors;
+        for (const element of footerElements) {
+            if (["BREAKING CHANGE", "BREAKING-CHANGE"].includes(element.key.toUpperCase())) {
+                if (element.key !== element.key.toUpperCase()) {
+                    errors.push(diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                        text: highlightString(this.description, "BREAKING CHANGE MUST be uppercase"),
+                        linenumber: element.lineNumber,
+                        column: 1,
+                    })
+                        .setContext(element.lineNumber, commit.commit.raw.split(/\r?\n/)[element.lineNumber - 1])
+                        .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+                }
+            }
+        }
         return errors;
     }
 }
@@ -2763,20 +2918,19 @@ class CC05 {
  * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
-    constructor() {
-        this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
-    }
+    id = "EC-01";
+    description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     validate(commit, options) {
-        var _a;
-        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
-        if (uniqueScopeList.length === 0)
+        const uniqueScopeList = Array.from(new Set(options?.scopes ?? []));
+        if (uniqueScopeList.length === 0) {
             return [];
-        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
+        }
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, ""))) {
             return [];
+        }
         this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
+            createDiagnosticsMessage(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
@@ -2784,33 +2938,74 @@ class EC01 {
  * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
-    constructor() {
-        this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
-    }
+    id = "EC-02";
+    description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     validate(commit, options) {
-        var _a;
-        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        const uniqueAddedTypes = new Set(options?.types ?? []);
         if (uniqueAddedTypes.has("feat"))
             uniqueAddedTypes.delete("feat");
         if (uniqueAddedTypes.has("fix"))
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        this.description = `Commits ${uniqueAddedTypes.size > 0 ? "MUST" : "MAY"} be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
         if (commit.type.value === undefined ||
             !isNoun(commit.type.value) ||
-            expectedTypes.includes(commit.type.value.trimEnd()))
+            expectedTypes.includes(commit.type.value.toLowerCase().trimEnd())) {
             return [];
-        if (commit.type.value.trim().length === 0) {
-            return [createError(commit, this.description, "prefixed with a type", "type")];
         }
-        return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
-        ];
+        if (commit.type.value.trim().length === 0) {
+            return [createDiagnosticsMessage(commit, this.description, "prefixed with a type", "type")];
+        }
+        if (uniqueAddedTypes.size > 0) {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
+            ];
+        }
+        else {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type", false, diagnose_it_1.DiagnosticsLevelEnum.Warning),
+            ];
+        }
+    }
+}
+/**
+ * A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.
+ */
+class WA01 {
+    id = "WA-01";
+    description = "A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.";
+    validate(commit, _options) {
+        const errors = [];
+        if (commit.commit.body === undefined)
+            return errors;
+        const elements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.body);
+        if (elements === undefined)
+            return errors;
+        for (const element of elements) {
+            if (element.key === "BREAKING CHANGE" || element.key === "BREAKING-CHANGE") {
+                errors.push(diagnose_it_1.DiagnosticsMessage.createWarning(commit.commit.hash, {
+                    text: highlightString(`A \`${element.key}\` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.`, [element.key, "will be ignored as it MUST be included in the footer"]),
+                    linenumber: commit.commit.subject.split(/\r?\n/).length + element.lineNumber,
+                    column: 1,
+                })
+                    .setContext(commit.commit.subject.split(/\r?\n/).length + 1, commit.commit.body.split(/\r?\n/))
+                    .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+            }
+        }
+        return errors;
     }
 }
 /** @internal */
-exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
+exports.commitRules = [
+    new CC01(),
+    new CC04(),
+    new CC05(),
+    new CC06(),
+    new CC15(),
+    new EC01(),
+    new EC02(),
+    new WA01(),
+];
 
 
 /***/ }),
@@ -41012,7 +41207,7 @@ class FileSource {
         }
     }
     async getCommitMessages() {
-        return [(0, commit_it_1.getCommit)({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
+        return [commit_it_1.Commit.fromString({ hash: "HEAD", message: fs.readFileSync(this.file, "utf8") })];
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41032,7 +41227,7 @@ class GitSource {
     }
     async getCommitMessages() {
         const data = await (0, simple_git_1.simpleGit)().log({ from: this.sourceBranch, to: "@{push}" });
-        return data.all.map(commit => (0, commit_it_1.getCommit)({ hash: commit.hash }));
+        return data.all.map(commit => commit_it_1.Commit.fromHash({ hash: commit.hash }));
     }
     async getConfigurationFile(path) {
         if (!fs.existsSync(path)) {
@@ -41051,13 +41246,10 @@ class GitHubSource {
         const pullRequestNumber = github.context.payload.pull_request?.number;
         (0, assert_1.default)(pullRequestNumber);
         const commits = await octokit.rest.pulls.listCommits({ ...github.context.repo, pull_number: pullRequestNumber });
-        return commits.data.map(commit => {
-            return {
-                hash: commit.sha,
-                subject: commit.commit.message.split(/\r?\n/)[0],
-                body: commit.commit.message.split(/\r?\n/).slice(2).join("\n"),
-            };
-        });
+        return commits.data.map(commit => commit_it_1.Commit.fromString({
+            hash: commit.sha,
+            message: commit.commit.message,
+        }));
     }
     /**
      * Retrieves the specified configuration file from the repository using the REST API
@@ -41122,12 +41314,15 @@ program
     await configuration_1.Configuration.getInstance().fromDatasource(datasource, program.opts().config);
     const commits = await datasource.getCommitMessages();
     let errorCount = 0;
+    let warningCount = 0;
     (0, validator_1.validateCommits)(commits).forEach(commit => {
-        commit.errors.forEach(error => console.log(error, os_1.default.EOL));
+        commit.errors.forEach(err => console.log(err.toString(), os_1.default.EOL));
+        commit.warnings.forEach(err => console.log(err.toString(), os_1.default.EOL));
         errorCount += commit.errors.length;
+        warningCount += commit.warnings.length;
     });
     if (errorCount > 0) {
-        program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+        program.error(`❌ Found ${errorCount} Conventional Commit compliance issues, and ${warningCount} warnings.`);
     }
 });
 program.parse(process.argv);
@@ -41155,16 +41350,7 @@ const configuration_1 = __nccwpck_require__(5778);
  * @returns Validation result
  */
 function validateCommit(commit) {
-    const result = { commit: commit, errors: [] };
-    try {
-        result.commit = (0, commit_it_1.getConventionalCommit)(commit, configuration_1.Configuration.getInstance());
-    }
-    catch (error) {
-        if (!(error instanceof commit_it_1.ConventionalCommitError))
-            throw error;
-        error.errors.forEach(e => result.errors.push(e.toString()));
-    }
-    return result;
+    return commit_it_1.ConventionalCommit.fromCommit(commit, configuration_1.Configuration.getInstance());
 }
 /**
  * Validates the pull request against CommitMe requirements.
@@ -41174,27 +41360,28 @@ function validateCommit(commit) {
  */
 function validatePullRequest(pullrequest, commits) {
     const result = validateCommit(pullrequest);
-    if (result.errors.length > 0)
+    if (!result.isValid)
         return result;
     const orderValue = (commit) => {
-        if (!commit || !("type" in commit))
-            return 0;
         if (commit.breaking)
             return 3;
-        if (commit.type === "feat")
+        if (commit.type?.toLowerCase() === "feat")
             return 2;
-        if (commit.type === "fix")
+        if (commit.type?.toLowerCase() === "fix")
             return 1;
         return 0;
     };
-    const pullRequestValue = orderValue(result.commit);
-    const commitsValue = orderValue(commits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
+    const pullRequestValue = orderValue(result);
+    const validConventionalCommits = commits.filter(commit => commit.isValid);
+    const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
-        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.commit.hash, {
+        result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
             text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
-        }).toString());
+        })
+            .setContext(1, result.subject)
+            .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: result.type?.length ?? 1 })));
     }
     return result;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1",
         "@actions/github": "^6",
-        "@dev-build-deploy/commit-it": "^1",
+        "@dev-build-deploy/commit-it": "^2",
         "@dev-build-deploy/diagnose-it": "^1",
         "commander": "^11",
         "simple-git": "^3"
@@ -743,12 +743,15 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.4.tgz",
-      "integrity": "sha512-dT0bfSmDnj2SD4qVedHuwTIozOcKwEOb5RulndCjXUSJ2IazA3U3VJMyqAf0TTY9h7au/HaKjokjMtomNNi+XA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.0.2.tgz",
+      "integrity": "sha512-gMcFU3ik5ikkx+xnwH9wdkucWhxONy7+5g+F7z/XEjzXPxJSY02WusxnCFu+KalTvc9T3bZbXyqtYClTMy5e8Q==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@dev-build-deploy/diagnose-it": {
@@ -2616,9 +2619,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.612",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.612.tgz",
-      "integrity": "sha512-dM8BMtXtlH237ecSMnYdYuCkib2QHq0kpWfUnavjdYsyr/6OsAwg5ZGUfnQ9KD1Ga4QgB2sqXlB2NT8zy2GnVg==",
+      "version": "1.4.614",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz",
+      "integrity": "sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2902,9 +2905,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.7",
@@ -2923,7 +2926,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -6267,9 +6270,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@actions/core": "^1",
     "@actions/github": "^6",
-    "@dev-build-deploy/commit-it": "^1",
+    "@dev-build-deploy/commit-it": "^2",
     "@dev-build-deploy/diagnose-it": "^1",
     "commander": "^11",
     "simple-git": "^3"

--- a/src/entrypoints/cli.ts
+++ b/src/entrypoints/cli.ts
@@ -45,23 +45,28 @@ program
     const commits = await datasource.getCommitMessages();
 
     let errorCount = 0;
+    let warningCount = 0;
     const results = validateCommits(commits);
 
     for (const commit of results) {
       console.log(
-        `${commit.errors.length === 0 ? "✅" : "❌"} ${commit.commit.hash}: ${commit.commit.subject.substring(0, 77)}${
-          commit.commit.subject.length > 80 ? "..." : ""
+        `${commit.errors.length === 0 ? "✅" : "❌"} ${commit.hash}: ${commit.subject.substring(0, 77)}${
+          commit.subject.length > 80 ? "..." : ""
         }`
       );
-      commit.errors.forEach(error => console.log(error, os.EOL));
+
+      commit.errors.forEach(err => console.log(err.toString(), os.EOL));
+      commit.warnings.forEach(err => console.log(err.toString(), os.EOL));
+
       errorCount += commit.errors.length;
+      warningCount += commit.warnings.length;
     }
 
     console.log("-------------------------------------------------------");
     if (errorCount === 0) {
       console.log(`✅ All your commits are compliant with Conventional Commit.`);
     } else {
-      program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+      program.error(`❌ Found ${errorCount} Conventional Commit compliance issues, and ${warningCount} warnings.`);
     }
   });
 

--- a/src/entrypoints/pre-commit.ts
+++ b/src/entrypoints/pre-commit.ts
@@ -31,13 +31,18 @@ program
     const commits = await datasource.getCommitMessages();
 
     let errorCount = 0;
+    let warningCount = 0;
+
     validateCommits(commits).forEach(commit => {
-      commit.errors.forEach(error => console.log(error, os.EOL));
+      commit.errors.forEach(err => console.log(err.toString(), os.EOL));
+      commit.warnings.forEach(err => console.log(err.toString(), os.EOL));
+
       errorCount += commit.errors.length;
+      warningCount += commit.warnings.length;
     });
 
     if (errorCount > 0) {
-      program.error(`❌ Found ${errorCount} Conventional Commit compliance issues.`);
+      program.error(`❌ Found ${errorCount} Conventional Commit compliance issues, and ${warningCount} warnings.`);
     }
   });
 


### PR DESCRIPTION
This commit will introduce the following new rules:
- `CC-06` -  A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
- `CC-15` - The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
- `WA-01` - A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.