### PR TITLE
feat: improve robustness of different configuration options

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -34,12 +34,6 @@ jobs:
                                  # Pull Request without requiring the `contents:write`
                                  # permission
           config: .github/.commit-me.json # Path to your CommitMe configuration file
-          types: |  # Limit the Conventional Commits type to the following values;
-            magic
-            void
-          scopes: | # Limit the Conventional Commits scopes to the following values;
-            foo
-            bar
         env:
           # Enable colored output in GitHub Actions
           FORCE_COLOR: 3

--- a/README.md
+++ b/README.md
@@ -20,23 +20,9 @@ Please refer to the document related to your environment for more details on the
 - [Command Line Interface](./docs/cli.md)
 - [Pre-commit Hook](./docs/pre-commit.md)
 
-## Configuration file
+## Configuration
 
-You can create a global configuration file:
-
-```json
-{
-  "types": [ "build", "chore", "ci", "docs", "style", "refactor", "perf", "test" ],
-  "scopes": [ "server", "client" ]
-}
-```
-
-| Configuration Item | Description |
-| -------------------| ------------|
-| `types`            | Conventional Commit types to allow. By default it always supports `feat` and `fix`. |
-| `scopes`           | Conventional Commit scopes to allow. No restrictions will be applied when not specified. |
-
-> :bulb: By default, CommitMe will attempt to load `.commit-me.json` in the root of your repository
+Please refer to the [Global Configuration documentation](./docs/config.md) for details on how to configure `CommitMe`.
 
 ## Contributing
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,47 @@
+<!-- 
+SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Global configuration file
+
+You can create a global configuration file, for example:
+
+```json
+{
+  "types": [ "build", "chore", "ci", "docs", "style", "refactor", "perf", "test" ],
+  "scopes": [ "server", "client" ],
+  "githubAction": {
+    "includeCommits": true,
+    "includePullRequest": true,
+    "updatePullRequestLabels": true,
+  }
+}
+```
+
+> [!NOTE]
+> By default, CommitMe will attempt to load `.commit-me.json` in the root of your repository
+
+## Generic settings
+
+The following settings will be taken into account for all `CommitMe` clients ([GitHub Action](./github-action.md), [CLI](./cli.md), and [Pre-Commit](./pre-commit.md))
+
+| Configuration Item | Description |
+| -------------------| ------------|
+| `types`            | Conventional Commit types to allow. By default it always supports `feat` and `fix`. |
+| `scopes`           | Conventional Commit scopes to allow. No restrictions will be applied when not specified. |
+
+## GitHub Actions settings
+
+You can also configure the majority of inputs for the [GitHub Action](./github-action.md) using the configuration file:
+
+| Configuration Item                     | Description |
+| ---------------------------------------| ------------|
+| `githubAction.includeCommits`          | Include commits associated with the Pull Request during validation; by default we use the repository configuration settings to determine this value (requires `contents:write` permission if **NOT** set). |
+| `githubAction.includePullRequest`      | Include the Pull Request during validation, defaults to `true`. |
+| `githubAction.updatePullRequestLabels` | Allow CommitMe to manage [labels](./github-action.md#pull-request-labels) based on the [Conventional Commits] metadata (requires `pull-requests:write` permission), defaults to `true` |
+
+> [!WARNING]
+> The inputs given to the GitHub Action take precedence over the configuration file
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -12,8 +12,8 @@ You can scan your [pull requests](#pull-request-scanning) for determining compli
 ## Validation strategies
 
 Currently there are two distinct [Conventional Commits] validation strategies implemented;
-- Validate the Pull Request title and all associated commits _(default behavior)_.
-- **ONLY** validate the Pull Request title.
+- Validate the Pull Request and all associated commits _(default behavior)_.
+- **ONLY** validate the Pull Request.
 
 Selection of the strategy is based on either:
 - The allowed merge strategies in your repository (the `contents: write` permission needs to be set in order for this detection to work.)
@@ -95,7 +95,7 @@ You can limit the Conventional Commit Type and/or Scope using the related input 
 - uses: dev-build-deploy/commit-me@v0
   with:
     # OPTIONAL; Enforce that each commit contains a predefined scope
-    scope: |
+    scopes: |
       backend
       frontend
     # OPTIONAL; Limit the Conventional Commits type to `feat`, `fix`, and a custom entries `docs` and `debt`
@@ -112,8 +112,8 @@ We recommend using the [`pull_request`](https://docs.github.com/en/actions/using
 In addition, we recommend the following activity types: 
 | Activity | Description |
 | --- | --- |
-| `opened` | Validates all commits in the source branch of your Pull Request upon opening the PR |
-| `edited` | Validates any change to the Pull Requests title |
+| `opened` | Validvates all commits in the source branch of your Pull Request upon opening the PR |
+| `edited` | Validates any change to the Pull Requests |
 | `synchronize` | Validate all subsequent commits added to the (open) Pull Request. This is only required in case rebase merges are enabled on the target repository. |
 
 > **NOTE**: Although supported, the trigger `pull_request_target` has elevated permissions to access secrets and your repository. Please refer to this [GitHub security blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for more details 
@@ -124,8 +124,13 @@ In addition, we recommend the following activity types:
 | --- | --- | --- |
 | `token` | *NO* | GitHub token needed to access your commits in your pull request. This is **only** required in case you want to:<br><ul><li>Validate commits associated with your Pull Request</li><li>Update labels in your Pull Request</li></ul> |
 | `update-labels` | *NO* | Allow CommitMe to manage [labels](#pull-request-labels) based on the [Conventional Commits] metadata (requires `pull-requests:write` permission), defaults to `true` |
-| `include-commits` | *NO* | Include commits associated with the Pull Request; by default we use the repository configuration settings to determine this value (requires `contents:write` permission if **NOT** set). |
+| `scopes` | *NO* | Conventional Commit scopes to allow. No restrictions will be applied when not specified. |
+| `types` | *NO* | Conventional Commit types to allow. By default it always supports `feat` and `fix`. |
+| `include-commits` | *NO* | Include commits associated with the Pull Request during validation; by default we use the repository configuration settings to determine this value (requires `contents:write` permission if **NOT** set). |
 | `config` | *NO* | Path to the configuration file; by default `.pre-commit.json` is used. |
+
+> [!NOTE]
+> You can also configure the majority of the inputs using the [Global Configuration file](./config.md#github-actions-settings)
 
 ### Permissions
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -46,6 +46,9 @@ jobs:
   commit-me:
     name: Conventional Commits Compliance
     runs-on: ubuntu-latest
+    env:
+      # Enable colored output in GitHub Actions
+      FORCE_COLOR: 3
     steps:
       - uses: dev-build-deploy/commit-me@v0
         with:
@@ -77,6 +80,9 @@ jobs:
   commit-me:
     name: Conventional Commits Compliance
     runs-on: ubuntu-latest
+    env:
+      # Enable colored output in GitHub Actions
+      FORCE_COLOR: 3
     steps:
       - uses: dev-build-deploy/commit-me@v0
         with:

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -41506,7 +41506,7 @@ async function run() {
         if (config.includePullRequest === true) {
             core.startGroup(`🔎 Scanning Pull Request`);
             const resultPullrequest = (0, validator_1.validatePullRequest)(commit_it_1.Commit.fromString({
-                hash: `#${github.context.payload.pull_request.number}`,
+                hash: `PullRequest`,
                 message: [github.context.payload.pull_request.title, "", github.context.payload.pull_request.body].join("\n"),
             }), allResults);
             allResults.push(resultPullrequest);

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -41727,6 +41727,10 @@ function validatePullRequest(pullrequest, commits) {
     };
     const pullRequestValue = orderValue(result);
     const validConventionalCommits = commits.filter(commit => commit.isValid);
+    // No valid commits found, return the pull request validation result
+    if (validConventionalCommits.length === 0)
+        return result;
+    // Sort the commits by order of precedence (SemVer) and validate against the Pull Request (SemVer)
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -2154,9 +2154,15 @@ class Commit {
      * @returns The commit object
      */
     static fromString(props) {
+        // Git will trim all comments (lines starting with #), so we do the same
+        // to ensure the commit message is parsed correctly.
+        const trimmedMessage = props.message
+            .split(/\r?\n/)
+            .filter(line => !line.startsWith("#"))
+            .join("\n");
         const commit = {
             hash: props.hash,
-            ...parseCommitMessage(props.message),
+            ...parseCommitMessage(trimmedMessage),
             author: props.author,
             committer: props.committer,
             raw: props.message,
@@ -13965,6 +13971,12 @@ function pick(source, properties) {
 function delay(duration = 0) {
   return new Promise((done) => setTimeout(done, duration));
 }
+function orVoid(input) {
+  if (input === false) {
+    return void 0;
+  }
+  return input;
+}
 var import_file_exists, NULL, NOOP, objectToString;
 var init_util = __esm({
   "src/lib/utils/util.ts"() {
@@ -14231,6 +14243,7 @@ __export(utils_exports, {
   isUserFunction: () => isUserFunction,
   last: () => last,
   objectToString: () => objectToString,
+  orVoid: () => orVoid,
   parseStringResponse: () => parseStringResponse,
   pick: () => pick,
   prefixedArray: () => prefixedArray,
@@ -14665,6 +14678,29 @@ var init_config = __esm({
   }
 });
 
+// src/lib/tasks/diff-name-status.ts
+function isDiffNameStatus(input) {
+  return diffNameStatus.has(input);
+}
+var DiffNameStatus, diffNameStatus;
+var init_diff_name_status = __esm({
+  "src/lib/tasks/diff-name-status.ts"() {
+    DiffNameStatus = /* @__PURE__ */ ((DiffNameStatus2) => {
+      DiffNameStatus2["ADDED"] = "A";
+      DiffNameStatus2["COPIED"] = "C";
+      DiffNameStatus2["DELETED"] = "D";
+      DiffNameStatus2["MODIFIED"] = "M";
+      DiffNameStatus2["RENAMED"] = "R";
+      DiffNameStatus2["CHANGED"] = "T";
+      DiffNameStatus2["UNMERGED"] = "U";
+      DiffNameStatus2["UNKNOWN"] = "X";
+      DiffNameStatus2["BROKEN"] = "B";
+      return DiffNameStatus2;
+    })(DiffNameStatus || {});
+    diffNameStatus = new Set(Object.values(DiffNameStatus));
+  }
+});
+
 // src/lib/tasks/grep.ts
 function grepQueryBuilder(...params) {
   return new GrepQuery().param(...params);
@@ -14788,6 +14824,7 @@ var api_exports = {};
 __export(api_exports, {
   CheckRepoActions: () => CheckRepoActions,
   CleanOptions: () => CleanOptions,
+  DiffNameStatus: () => DiffNameStatus,
   GitConfigScope: () => GitConfigScope,
   GitConstructError: () => GitConstructError,
   GitError: () => GitError,
@@ -14809,6 +14846,7 @@ var init_api = __esm({
     init_check_is_repo();
     init_clean();
     init_config();
+    init_diff_name_status();
     init_grep();
     init_reset();
   }
@@ -15864,6 +15902,7 @@ var init_parse_diff_summary = __esm({
   "src/lib/parsers/parse-diff-summary.ts"() {
     init_log_format();
     init_DiffSummary();
+    init_diff_name_status();
     init_utils();
     statParser = [
       new LineParser(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = ""]) => {
@@ -15929,11 +15968,12 @@ var init_parse_diff_summary = __esm({
       })
     ];
     nameStatusParser = [
-      new LineParser(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+      new LineParser(/([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/, (result, [status, _similarity, from, _to, to]) => {
         result.changed++;
         result.files.push({
-          file,
+          file: to != null ? to : from,
           changes: 0,
+          status: orVoid(isDiffNameStatus(status) && status),
           insertions: 0,
           deletions: 0,
           binary: false
@@ -41071,17 +41111,47 @@ function wrappy (fn, cb) {
 /***/ }),
 
 /***/ 5778:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
 /*
  * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
  * SPDX-License-Identifier: MIT
  */
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+const assert_1 = __importDefault(__nccwpck_require__(9491));
+const core = __importStar(__nccwpck_require__(2186));
+const github = __importStar(__nccwpck_require__(5438));
 const datasources_1 = __nccwpck_require__(1751);
+const repository = __importStar(__nccwpck_require__(259));
 /**
  * Configuration class
  * @class Configuration
@@ -41094,6 +41164,7 @@ class Configuration {
     static _instance;
     includeCommits = false;
     includePullRequest = false;
+    updatePullRequestLabels = false;
     scopes;
     types;
     static getInstance() {
@@ -41130,23 +41201,48 @@ class Configuration {
      */
     async fromDatasource(datasource, configPath) {
         const content = await datasource.getConfigurationFile(configPath ?? ".commit-me.json");
-        if (!content)
-            return this;
+        const config = content ? JSON.parse(content) : {};
         if (datasource instanceof datasources_1.GitSource || datasource instanceof datasources_1.FileSource) {
             this.includeCommits = true;
             this.includePullRequest = false;
+            this.updatePullRequestLabels = false;
+            this.addScopes(config.scopes ?? []);
+            this.addTypes(config.types ?? []);
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
-            this.includePullRequest = true;
+            const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
+            const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            if (autoDetectIncludeCommits) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                repository.checkConfiguration(github.context.payload.pull_request.base.repo);
+                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includeCommits = hasIncludeCommitsInput
+                    ? core.getBooleanInput("include-commits")
+                    : config.githubAction?.includeCommits ?? false;
+            }
+            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (core.getMultilineInput("scopes").length > 0) {
+                this.addScopes(core.getMultilineInput("scopes"));
+            }
+            else {
+                this.addScopes(config.scopes ?? []);
+            }
+            if (core.getMultilineInput("types").length > 0) {
+                this.addTypes(core.getMultilineInput("types"));
+            }
+            else {
+                this.addTypes(config.types ?? []);
+            }
+            this.updatePullRequestLabels = hasPullRequestLabelsInput
+                ? core.getBooleanInput("update-labels")
+                : config.githubAction?.updatePullRequestLabels ?? false;
         }
         else {
             throw new Error("Unsupported data source");
         }
-        const config = JSON.parse(content);
-        this.includeCommits = config.includeCommits ?? this.includeCommits;
-        this.includePullRequest = config.includePullRequest ?? this.includePullRequest;
-        this.addScopes(config.scopes ?? []);
-        this.addTypes(config.types ?? []);
         return this;
     }
 }
@@ -41327,7 +41423,6 @@ const commit_it_1 = __nccwpck_require__(9403);
 const configuration_1 = __nccwpck_require__(5778);
 const datasources_1 = __nccwpck_require__(1751);
 const github_1 = __nccwpck_require__(978);
-const repository = __importStar(__nccwpck_require__(259));
 const validator_1 = __nccwpck_require__(4630);
 /**
  * Determines the label to be applied to the pull request.
@@ -41365,27 +41460,15 @@ const reportErrorMessages = (results) => {
     }
     return { errors: errorCount, warnings: warningCount };
 };
-const setConfiguration = async (dataSource) => {
-    (0, assert_1.default)(github.context.payload.pull_request);
-    const pullrequestOnly = core.getInput("include-commits")
-        ? !core.getBooleanInput("include-commits")
-        : github.context.payload.pull_request.base.repo.allow_rebase_merge === false;
-    // Set the global configuration
-    const config = await configuration_1.Configuration.getInstance().fromDatasource(dataSource, core.getInput("config") || undefined);
-    config.includeCommits = !pullrequestOnly;
-    config.addScopes(core.getMultilineInput("scopes") ?? []);
-    config.addTypes(core.getMultilineInput("types") ?? []);
-};
 /**
  * Main entry point for the GitHub Action.
  */
 async function run() {
     try {
         core.info("📄 CommitMe - Conventional Commit compliance validation");
-        const datasource = new datasources_1.GitHubSource();
-        await setConfiguration(datasource);
         core.startGroup("📝 Checking repository configuration");
-        const config = configuration_1.Configuration.getInstance();
+        const datasource = new datasources_1.GitHubSource();
+        const config = await configuration_1.Configuration.getInstance().fromDatasource(datasource, core.getInput("config") || undefined);
         const githubToken = core.getInput("token") ?? undefined;
         (0, assert_1.default)(github.context.payload.pull_request);
         if (!["pull_request", "pull_request_target"].includes(github.context.eventName)) {
@@ -41396,13 +41479,21 @@ async function run() {
             core.setFailed("❌ The `token` input is required for the current configuration of CommitMe.");
             return;
         }
-        if (core.getInput("include-commits") === undefined) {
-            repository.checkConfiguration(github.context.payload.pull_request.base.repo);
+        if (config.includeCommits === true) {
+            if (config.includePullRequest === true) {
+                core.info("ℹ️ Validating both Pull Request and all associated commits.");
+            }
+            else {
+                core.info("ℹ️ Only validating the commits associated with the Pull Request.");
+            }
         }
         else {
-            core.info(config.includeCommits === true
-                ? "ℹ️ Validating both Pull Request title and all associated commits."
-                : "ℹ️ Only validating the Pull Request title.");
+            if (config.includePullRequest === true) {
+                core.info("ℹ️ Only validating the Pull Request.");
+            }
+            else {
+                core.setFailed("❌ The current configuration of CommitMe does not validate either Pull Request or the associated commits.");
+            }
         }
         // Setting up the environment
         const commits = config.includeCommits ? await datasource.getCommitMessages() : [];
@@ -41442,7 +41533,7 @@ async function run() {
         if (githubToken === undefined) {
             core.warning("⚠️ The token input is required to update the pull request label.");
         }
-        else if (core.getBooleanInput("update-labels") === true) {
+        else if (config.updatePullRequestLabels === true) {
             const label = await determineLabel(allResults);
             if (label !== undefined)
                 await (0, github_1.updatePullRequestLabels)(label);
@@ -41639,7 +41730,7 @@ function validatePullRequest(pullrequest, commits) {
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
-            text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
+            text: `A Pull Request MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
         })

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2155,9 +2155,15 @@ class Commit {
      * @returns The commit object
      */
     static fromString(props) {
+        // Git will trim all comments (lines starting with #), so we do the same
+        // to ensure the commit message is parsed correctly.
+        const trimmedMessage = props.message
+            .split(/\r?\n/)
+            .filter(line => !line.startsWith("#"))
+            .join("\n");
         const commit = {
             hash: props.hash,
-            ...parseCommitMessage(props.message),
+            ...parseCommitMessage(trimmedMessage),
             author: props.author,
             committer: props.committer,
             raw: props.message,
@@ -13966,6 +13972,12 @@ function pick(source, properties) {
 function delay(duration = 0) {
   return new Promise((done) => setTimeout(done, duration));
 }
+function orVoid(input) {
+  if (input === false) {
+    return void 0;
+  }
+  return input;
+}
 var import_file_exists, NULL, NOOP, objectToString;
 var init_util = __esm({
   "src/lib/utils/util.ts"() {
@@ -14232,6 +14244,7 @@ __export(utils_exports, {
   isUserFunction: () => isUserFunction,
   last: () => last,
   objectToString: () => objectToString,
+  orVoid: () => orVoid,
   parseStringResponse: () => parseStringResponse,
   pick: () => pick,
   prefixedArray: () => prefixedArray,
@@ -14666,6 +14679,29 @@ var init_config = __esm({
   }
 });
 
+// src/lib/tasks/diff-name-status.ts
+function isDiffNameStatus(input) {
+  return diffNameStatus.has(input);
+}
+var DiffNameStatus, diffNameStatus;
+var init_diff_name_status = __esm({
+  "src/lib/tasks/diff-name-status.ts"() {
+    DiffNameStatus = /* @__PURE__ */ ((DiffNameStatus2) => {
+      DiffNameStatus2["ADDED"] = "A";
+      DiffNameStatus2["COPIED"] = "C";
+      DiffNameStatus2["DELETED"] = "D";
+      DiffNameStatus2["MODIFIED"] = "M";
+      DiffNameStatus2["RENAMED"] = "R";
+      DiffNameStatus2["CHANGED"] = "T";
+      DiffNameStatus2["UNMERGED"] = "U";
+      DiffNameStatus2["UNKNOWN"] = "X";
+      DiffNameStatus2["BROKEN"] = "B";
+      return DiffNameStatus2;
+    })(DiffNameStatus || {});
+    diffNameStatus = new Set(Object.values(DiffNameStatus));
+  }
+});
+
 // src/lib/tasks/grep.ts
 function grepQueryBuilder(...params) {
   return new GrepQuery().param(...params);
@@ -14789,6 +14825,7 @@ var api_exports = {};
 __export(api_exports, {
   CheckRepoActions: () => CheckRepoActions,
   CleanOptions: () => CleanOptions,
+  DiffNameStatus: () => DiffNameStatus,
   GitConfigScope: () => GitConfigScope,
   GitConstructError: () => GitConstructError,
   GitError: () => GitError,
@@ -14810,6 +14847,7 @@ var init_api = __esm({
     init_check_is_repo();
     init_clean();
     init_config();
+    init_diff_name_status();
     init_grep();
     init_reset();
   }
@@ -15865,6 +15903,7 @@ var init_parse_diff_summary = __esm({
   "src/lib/parsers/parse-diff-summary.ts"() {
     init_log_format();
     init_DiffSummary();
+    init_diff_name_status();
     init_utils();
     statParser = [
       new LineParser(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = ""]) => {
@@ -15930,11 +15969,12 @@ var init_parse_diff_summary = __esm({
       })
     ];
     nameStatusParser = [
-      new LineParser(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+      new LineParser(/([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/, (result, [status, _similarity, from, _to, to]) => {
         result.changed++;
         result.files.push({
-          file,
+          file: to != null ? to : from,
           changes: 0,
+          status: orVoid(isDiffNameStatus(status) && status),
           insertions: 0,
           deletions: 0,
           binary: false
@@ -41072,17 +41112,47 @@ function wrappy (fn, cb) {
 /***/ }),
 
 /***/ 5778:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
 /*
  * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
  * SPDX-License-Identifier: MIT
  */
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+const assert_1 = __importDefault(__nccwpck_require__(9491));
+const core = __importStar(__nccwpck_require__(2186));
+const github = __importStar(__nccwpck_require__(5438));
 const datasources_1 = __nccwpck_require__(1751);
+const repository = __importStar(__nccwpck_require__(259));
 /**
  * Configuration class
  * @class Configuration
@@ -41095,6 +41165,7 @@ class Configuration {
     static _instance;
     includeCommits = false;
     includePullRequest = false;
+    updatePullRequestLabels = false;
     scopes;
     types;
     static getInstance() {
@@ -41131,23 +41202,48 @@ class Configuration {
      */
     async fromDatasource(datasource, configPath) {
         const content = await datasource.getConfigurationFile(configPath ?? ".commit-me.json");
-        if (!content)
-            return this;
+        const config = content ? JSON.parse(content) : {};
         if (datasource instanceof datasources_1.GitSource || datasource instanceof datasources_1.FileSource) {
             this.includeCommits = true;
             this.includePullRequest = false;
+            this.updatePullRequestLabels = false;
+            this.addScopes(config.scopes ?? []);
+            this.addTypes(config.types ?? []);
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
-            this.includePullRequest = true;
+            const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
+            const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            if (autoDetectIncludeCommits) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                repository.checkConfiguration(github.context.payload.pull_request.base.repo);
+                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includeCommits = hasIncludeCommitsInput
+                    ? core.getBooleanInput("include-commits")
+                    : config.githubAction?.includeCommits ?? false;
+            }
+            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (core.getMultilineInput("scopes").length > 0) {
+                this.addScopes(core.getMultilineInput("scopes"));
+            }
+            else {
+                this.addScopes(config.scopes ?? []);
+            }
+            if (core.getMultilineInput("types").length > 0) {
+                this.addTypes(core.getMultilineInput("types"));
+            }
+            else {
+                this.addTypes(config.types ?? []);
+            }
+            this.updatePullRequestLabels = hasPullRequestLabelsInput
+                ? core.getBooleanInput("update-labels")
+                : config.githubAction?.updatePullRequestLabels ?? false;
         }
         else {
             throw new Error("Unsupported data source");
         }
-        const config = JSON.parse(content);
-        this.includeCommits = config.includeCommits ?? this.includeCommits;
-        this.includePullRequest = config.includePullRequest ?? this.includePullRequest;
-        this.addScopes(config.scopes ?? []);
-        this.addTypes(config.types ?? []);
         return this;
     }
 }
@@ -41351,6 +41447,78 @@ program.parse(process.argv);
 
 /***/ }),
 
+/***/ 259:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.checkConfiguration = void 0;
+const core = __importStar(__nccwpck_require__(2186));
+/**
+ * Checks the repository merge configuration;
+ * - Whether merge commits are enabled and whether the default subject is based on the Pull Request title
+ * - Whether squash commits are enabled and whether the default subject is based on the Pull Request title
+ * - Whether rebase commits are enabled
+ */
+function checkConfiguration(repository) {
+    if (repository.allow_merge_commit === undefined ||
+        repository.allow_squash_merge === undefined ||
+        repository.allow_rebase_merge === undefined) {
+        throw new Error("❌ CommitMe is not configured correctly. Please provide either:\n - The `contents: write` permission, or\n - Use the `include-commits` input parameter.");
+    }
+    if (repository.allow_merge_commit) {
+        core.info(repository.merge_commit_title === "PR_TITLE"
+            ? "✅ Default merge commit subject will use the Pull Request title."
+            : "⚠️ Default merge commit subject is not based on your Pull Request title.");
+    }
+    else {
+        core.info("ℹ️ Merge commit strategy is disabled.");
+    }
+    if (repository.allow_squash_merge === true) {
+        core.info(repository.squash_merge_commit_title === "PR_TITLE"
+            ? "✅ Default squash commit subject will use the Pull Request title."
+            : "⚠️ Default squash commit subject is based on either your Commit message or Pull Request title.");
+    }
+    else {
+        core.info("ℹ️ Squash commit strategy is disabled.");
+    }
+    core.info(repository.allow_rebase_merge === true
+        ? "ℹ️ Rebase merges are enabled, validating both Pull Request title and all associated commits."
+        : "ℹ️ Rebase merges are disabled, only validating the Pull Request title.");
+}
+exports.checkConfiguration = checkConfiguration;
+
+
+/***/ }),
+
 /***/ 4630:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -41397,7 +41565,7 @@ function validatePullRequest(pullrequest, commits) {
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
-            text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
+            text: `A Pull Request MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
         })

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41562,6 +41562,10 @@ function validatePullRequest(pullrequest, commits) {
     };
     const pullRequestValue = orderValue(result);
     const validConventionalCommits = commits.filter(commit => commit.isValid);
+    // No valid commits found, return the pull request validation result
+    if (validConventionalCommits.length === 0)
+        return result;
+    // Sort the commits by order of precedence (SemVer) and validate against the Pull Request (SemVer)
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -2155,9 +2155,15 @@ class Commit {
      * @returns The commit object
      */
     static fromString(props) {
+        // Git will trim all comments (lines starting with #), so we do the same
+        // to ensure the commit message is parsed correctly.
+        const trimmedMessage = props.message
+            .split(/\r?\n/)
+            .filter(line => !line.startsWith("#"))
+            .join("\n");
         const commit = {
             hash: props.hash,
-            ...parseCommitMessage(props.message),
+            ...parseCommitMessage(trimmedMessage),
             author: props.author,
             committer: props.committer,
             raw: props.message,
@@ -13966,6 +13972,12 @@ function pick(source, properties) {
 function delay(duration = 0) {
   return new Promise((done) => setTimeout(done, duration));
 }
+function orVoid(input) {
+  if (input === false) {
+    return void 0;
+  }
+  return input;
+}
 var import_file_exists, NULL, NOOP, objectToString;
 var init_util = __esm({
   "src/lib/utils/util.ts"() {
@@ -14232,6 +14244,7 @@ __export(utils_exports, {
   isUserFunction: () => isUserFunction,
   last: () => last,
   objectToString: () => objectToString,
+  orVoid: () => orVoid,
   parseStringResponse: () => parseStringResponse,
   pick: () => pick,
   prefixedArray: () => prefixedArray,
@@ -14666,6 +14679,29 @@ var init_config = __esm({
   }
 });
 
+// src/lib/tasks/diff-name-status.ts
+function isDiffNameStatus(input) {
+  return diffNameStatus.has(input);
+}
+var DiffNameStatus, diffNameStatus;
+var init_diff_name_status = __esm({
+  "src/lib/tasks/diff-name-status.ts"() {
+    DiffNameStatus = /* @__PURE__ */ ((DiffNameStatus2) => {
+      DiffNameStatus2["ADDED"] = "A";
+      DiffNameStatus2["COPIED"] = "C";
+      DiffNameStatus2["DELETED"] = "D";
+      DiffNameStatus2["MODIFIED"] = "M";
+      DiffNameStatus2["RENAMED"] = "R";
+      DiffNameStatus2["CHANGED"] = "T";
+      DiffNameStatus2["UNMERGED"] = "U";
+      DiffNameStatus2["UNKNOWN"] = "X";
+      DiffNameStatus2["BROKEN"] = "B";
+      return DiffNameStatus2;
+    })(DiffNameStatus || {});
+    diffNameStatus = new Set(Object.values(DiffNameStatus));
+  }
+});
+
 // src/lib/tasks/grep.ts
 function grepQueryBuilder(...params) {
   return new GrepQuery().param(...params);
@@ -14789,6 +14825,7 @@ var api_exports = {};
 __export(api_exports, {
   CheckRepoActions: () => CheckRepoActions,
   CleanOptions: () => CleanOptions,
+  DiffNameStatus: () => DiffNameStatus,
   GitConfigScope: () => GitConfigScope,
   GitConstructError: () => GitConstructError,
   GitError: () => GitError,
@@ -14810,6 +14847,7 @@ var init_api = __esm({
     init_check_is_repo();
     init_clean();
     init_config();
+    init_diff_name_status();
     init_grep();
     init_reset();
   }
@@ -15865,6 +15903,7 @@ var init_parse_diff_summary = __esm({
   "src/lib/parsers/parse-diff-summary.ts"() {
     init_log_format();
     init_DiffSummary();
+    init_diff_name_status();
     init_utils();
     statParser = [
       new LineParser(/(.+)\s+\|\s+(\d+)(\s+[+\-]+)?$/, (result, [file, changes, alterations = ""]) => {
@@ -15930,11 +15969,12 @@ var init_parse_diff_summary = __esm({
       })
     ];
     nameStatusParser = [
-      new LineParser(/([ACDMRTUXB])\s*(.+)$/, (result, [_status, file]) => {
+      new LineParser(/([ACDMRTUXB])([0-9]{0,3})\t(.[^\t]*)(\t(.[^\t]*))?$/, (result, [status, _similarity, from, _to, to]) => {
         result.changed++;
         result.files.push({
-          file,
+          file: to != null ? to : from,
           changes: 0,
+          status: orVoid(isDiffNameStatus(status) && status),
           insertions: 0,
           deletions: 0,
           binary: false
@@ -41072,17 +41112,47 @@ function wrappy (fn, cb) {
 /***/ }),
 
 /***/ 5778:
-/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Configuration = void 0;
 /*
  * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
  * SPDX-License-Identifier: MIT
  */
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.Configuration = void 0;
+const assert_1 = __importDefault(__nccwpck_require__(9491));
+const core = __importStar(__nccwpck_require__(2186));
+const github = __importStar(__nccwpck_require__(5438));
 const datasources_1 = __nccwpck_require__(1751);
+const repository = __importStar(__nccwpck_require__(259));
 /**
  * Configuration class
  * @class Configuration
@@ -41095,6 +41165,7 @@ class Configuration {
     static _instance;
     includeCommits = false;
     includePullRequest = false;
+    updatePullRequestLabels = false;
     scopes;
     types;
     static getInstance() {
@@ -41131,23 +41202,48 @@ class Configuration {
      */
     async fromDatasource(datasource, configPath) {
         const content = await datasource.getConfigurationFile(configPath ?? ".commit-me.json");
-        if (!content)
-            return this;
+        const config = content ? JSON.parse(content) : {};
         if (datasource instanceof datasources_1.GitSource || datasource instanceof datasources_1.FileSource) {
             this.includeCommits = true;
             this.includePullRequest = false;
+            this.updatePullRequestLabels = false;
+            this.addScopes(config.scopes ?? []);
+            this.addTypes(config.types ?? []);
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
-            this.includePullRequest = true;
+            const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
+            const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            if (autoDetectIncludeCommits) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                repository.checkConfiguration(github.context.payload.pull_request.base.repo);
+                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includeCommits = hasIncludeCommitsInput
+                    ? core.getBooleanInput("include-commits")
+                    : config.githubAction?.includeCommits ?? false;
+            }
+            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (core.getMultilineInput("scopes").length > 0) {
+                this.addScopes(core.getMultilineInput("scopes"));
+            }
+            else {
+                this.addScopes(config.scopes ?? []);
+            }
+            if (core.getMultilineInput("types").length > 0) {
+                this.addTypes(core.getMultilineInput("types"));
+            }
+            else {
+                this.addTypes(config.types ?? []);
+            }
+            this.updatePullRequestLabels = hasPullRequestLabelsInput
+                ? core.getBooleanInput("update-labels")
+                : config.githubAction?.updatePullRequestLabels ?? false;
         }
         else {
             throw new Error("Unsupported data source");
         }
-        const config = JSON.parse(content);
-        this.includeCommits = config.includeCommits ?? this.includeCommits;
-        this.includePullRequest = config.includePullRequest ?? this.includePullRequest;
-        this.addScopes(config.scopes ?? []);
-        this.addTypes(config.types ?? []);
         return this;
     }
 }
@@ -41334,6 +41430,78 @@ program.parse(process.argv);
 
 /***/ }),
 
+/***/ 259:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.checkConfiguration = void 0;
+const core = __importStar(__nccwpck_require__(2186));
+/**
+ * Checks the repository merge configuration;
+ * - Whether merge commits are enabled and whether the default subject is based on the Pull Request title
+ * - Whether squash commits are enabled and whether the default subject is based on the Pull Request title
+ * - Whether rebase commits are enabled
+ */
+function checkConfiguration(repository) {
+    if (repository.allow_merge_commit === undefined ||
+        repository.allow_squash_merge === undefined ||
+        repository.allow_rebase_merge === undefined) {
+        throw new Error("❌ CommitMe is not configured correctly. Please provide either:\n - The `contents: write` permission, or\n - Use the `include-commits` input parameter.");
+    }
+    if (repository.allow_merge_commit) {
+        core.info(repository.merge_commit_title === "PR_TITLE"
+            ? "✅ Default merge commit subject will use the Pull Request title."
+            : "⚠️ Default merge commit subject is not based on your Pull Request title.");
+    }
+    else {
+        core.info("ℹ️ Merge commit strategy is disabled.");
+    }
+    if (repository.allow_squash_merge === true) {
+        core.info(repository.squash_merge_commit_title === "PR_TITLE"
+            ? "✅ Default squash commit subject will use the Pull Request title."
+            : "⚠️ Default squash commit subject is based on either your Commit message or Pull Request title.");
+    }
+    else {
+        core.info("ℹ️ Squash commit strategy is disabled.");
+    }
+    core.info(repository.allow_rebase_merge === true
+        ? "ℹ️ Rebase merges are enabled, validating both Pull Request title and all associated commits."
+        : "ℹ️ Rebase merges are disabled, only validating the Pull Request title.");
+}
+exports.checkConfiguration = checkConfiguration;
+
+
+/***/ }),
+
 /***/ 4630:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -41380,7 +41548,7 @@ function validatePullRequest(pullrequest, commits) {
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {
-            text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
+            text: `A Pull Request MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
             linenumber: 1,
             column: 1,
         })

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -41545,6 +41545,10 @@ function validatePullRequest(pullrequest, commits) {
     };
     const pullRequestValue = orderValue(result);
     const validConventionalCommits = commits.filter(commit => commit.isValid);
+    // No valid commits found, return the pull request validation result
+    if (validConventionalCommits.length === 0)
+        return result;
+    // Sort the commits by order of precedence (SemVer) and validate against the Pull Request (SemVer)
     const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
     if (pullRequestValue < commitsValue) {
         result.errors.push(diagnose_it_1.DiagnosticsMessage.createError(result.hash, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
-      "integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -197,10 +197,10 @@
         "@babel/generator": "^7.23.6",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.6",
+        "@babel/helpers": "^7.23.7",
         "@babel/parser": "^7.23.6",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.6",
+        "@babel/traverse": "^7.23.7",
         "@babel/types": "^7.23.6",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -391,13 +391,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
-      "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.6",
+        "@babel/traverse": "^7.23.7",
         "@babel/types": "^7.23.6"
       },
       "engines": {
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
-      "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
@@ -743,9 +743,9 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.0.3.tgz",
-      "integrity": "sha512-snSsstI8kytKXmEY5MXxj0pYM2t1JD0uf2uOTQSgHg6pKfC1A8YeiCUFPqbNFSeALLI580RZ3FafTTvU+Gyjyw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.0.4.tgz",
+      "integrity": "sha512-yhAj8RH0c8w4VCGYbt77JnRxemb/uwQrC/LpHEs0euiCTooTZW8VTGXgsOH/KnJC0lHeSoIHNF/Axk2UPSnU9A==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"
@@ -819,6 +819,28 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
@@ -837,17 +859,39 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -864,9 +908,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1294,9 +1338,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
+      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1532,9 +1576,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.20.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.20.7"
@@ -1596,9 +1640,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
-      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "version": "18.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.8.tgz",
+      "integrity": "sha512-g1pZtPhsvGVTwmeVoexWZLTQaOvXwoSq//pTL0DHeNzUDrFnir4fgETdhjhIxjVnN+hKOuh98+E1eMLnUXstFg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1643,16 +1687,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.14.0.tgz",
-      "integrity": "sha512-1ZJBykBCXaSHG94vMMKmiHoL0MhNHKSVlcHVYZNw+BKxufhqQVTOawNpwwI1P5nIFZ/4jLVop0mcY6mJJDFNaw==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.19.0.tgz",
+      "integrity": "sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/type-utils": "6.14.0",
-        "@typescript-eslint/utils": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.19.0",
+        "@typescript-eslint/type-utils": "6.19.0",
+        "@typescript-eslint/utils": "6.19.0",
+        "@typescript-eslint/visitor-keys": "6.19.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1678,15 +1722,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.14.0.tgz",
-      "integrity": "sha512-QjToC14CKacd4Pa7JK4GeB/vHmWFJckec49FR4hmIRf97+KXole0T97xxu9IFiPxVQ1DBWrQ5wreLwAGwWAVQA==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.19.0.tgz",
+      "integrity": "sha512-1DyBLG5SH7PYCd00QlroiW60YJ4rWMuUGa/JBV0iZuqi4l4IK3twKPq5ZkEebmGqRjXWVgsUzfd3+nZveewgow==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/typescript-estree": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.19.0",
+        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/typescript-estree": "6.19.0",
+        "@typescript-eslint/visitor-keys": "6.19.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1706,13 +1750,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
-      "integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.0.tgz",
+      "integrity": "sha512-dO1XMhV2ehBI6QN8Ufi7I10wmUovmLU0Oru3n5LVlM2JuzB4M+dVphCPLkVpKvGij2j/pHBWuJ9piuXx+BhzxQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0"
+        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/visitor-keys": "6.19.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1723,13 +1767,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
-      "integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.0.tgz",
+      "integrity": "sha512-mcvS6WSWbjiSxKCwBcXtOM5pRkPQ6kcDds/juxcy/727IQr3xMEcwr/YLHW2A2+Fp5ql6khjbKBzOyjuPqGi/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.14.0",
-        "@typescript-eslint/utils": "6.14.0",
+        "@typescript-eslint/typescript-estree": "6.19.0",
+        "@typescript-eslint/utils": "6.19.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1750,9 +1794,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
-      "integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.0.tgz",
+      "integrity": "sha512-lFviGV/vYhOy3m8BJ/nAKoAyNhInTdXpftonhWle66XHAtT1ouBlkjL496b5H5hb8dWXHwtypTqgtb/DEa+j5A==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1763,16 +1807,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
-      "integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.0.tgz",
+      "integrity": "sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/visitor-keys": "6.14.0",
+        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/visitor-keys": "6.19.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1790,17 +1835,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
-      "integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.0.tgz",
+      "integrity": "sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.14.0",
-        "@typescript-eslint/types": "6.14.0",
-        "@typescript-eslint/typescript-estree": "6.14.0",
+        "@typescript-eslint/scope-manager": "6.19.0",
+        "@typescript-eslint/types": "6.19.0",
+        "@typescript-eslint/typescript-estree": "6.19.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1815,12 +1860,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
-      "integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.0.tgz",
+      "integrity": "sha512-hZaUCORLgubBvtGpp1JEFEazcuEdfxta9j4iUwdSAr7mEsYYAp3EAUyCZk3VEEqGj6W+AV4uWyrDGtrlawAsgQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.14.0",
+        "@typescript-eslint/types": "6.19.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1847,9 +1892,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2209,13 +2254,12 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -2322,9 +2366,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001570",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+      "version": "1.0.30001578",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001578.tgz",
+      "integrity": "sha512-J/jkFgsQ3NEl4w2lCoM9ZPxrD+FoBNJ7uJUpGVjIg/j0OwJosWM36EPDv+Yyi0V4twBk9pPmlFS+PLykgEvUmg==",
       "dev": true,
       "funding": [
         {
@@ -2619,9 +2663,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.614",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz",
-      "integrity": "sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ==",
+      "version": "1.4.635",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.635.tgz",
+      "integrity": "sha512-iu/2D0zolKU3iDGXXxdOzNf72Jnokn+K1IN6Kk4iV6l1Tr2g/qy+mvmtfAiBwZe5S3aB5r92vp+zSZ69scYRrg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2935,6 +2979,16 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -2956,6 +3010,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -2966,9 +3032,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.0.tgz",
-      "integrity": "sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==",
+      "version": "27.6.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.3.tgz",
+      "integrity": "sha512-+YsJFVH6R+tOiO3gCJon5oqn4KWc+mDq2leudk8mrp8RFubLOo9CVyi3cib4L7XMpxExmkmBZQTPDYVBzgpgOA==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -3140,6 +3206,28 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -3307,9 +3395,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3561,6 +3649,28 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/globals": {
@@ -4962,15 +5072,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -5064,30 +5177,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm-run-all2/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm-run-path": {
@@ -5448,9 +5537,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -5620,9 +5709,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
-      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.9.0.tgz",
+      "integrity": "sha512-KS/6lh/ynPGiHD/LnAobrEFq3Ad4pBzOlJ1wAnJx9N4EYoqFhMfLIBjUT2UEx4wg5ZE+cC1ob6DCSpppVo+rtg==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -5771,13 +5860,13 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
+      "integrity": "sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
         "has-symbols": "^1.0.3",
         "isarray": "^2.0.5"
       },
@@ -5789,14 +5878,17 @@
       }
     },
     "node_modules/safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.2.tgz",
+      "integrity": "sha512-83S9w6eFq12BBIJYvjMux6/dkirb8+4zJRA9cxNBVb7Wq5fJBW+Xze48WqR8pxua7bDuAaaAxtVVd4Idjp1dBQ==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "call-bind": "^1.0.5",
+        "get-intrinsic": "^1.2.2",
         "is-regex": "^1.1.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5836,15 +5928,16 @@
       "dev": true
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
       "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5915,9 +6008,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.21.0.tgz",
-      "integrity": "sha512-oTzw9248AF5bDTMk9MrxsRzEzivMlY+DWH0yWS4VYpMhNLhDWnN06pCtaUyPnqv/FpsdeNmRqmZugMABHRPdDA==",
+      "version": "3.22.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.22.0.tgz",
+      "integrity": "sha512-6JujwSs0ac82jkGjMHiCnTifvf1crOiY/+tfs/Pqih6iow7VrpNKRRNdWm6RtaXpvvv/JGNYhlUtLhGFqHF+Yw==",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
@@ -6179,6 +6272,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {

--- a/src/entrypoints/action.ts
+++ b/src/entrypoints/action.ts
@@ -110,7 +110,7 @@ async function run(): Promise<void> {
       core.startGroup(`🔎 Scanning Pull Request`);
       const resultPullrequest = validatePullRequest(
         Commit.fromString({
-          hash: `#${github.context.payload.pull_request.number}`,
+          hash: `PullRequest`,
           message: [github.context.payload.pull_request.title, "", github.context.payload.pull_request.body].join("\n"),
         }),
         allResults

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -42,7 +42,7 @@ export function validatePullRequest(pullrequest: Commit, commits: ConventionalCo
   if (pullRequestValue < commitsValue) {
     result.errors.push(
       DiagnosticsMessage.createError(result.hash, {
-        text: `A Pull Request title MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
+        text: `A Pull Request MUST correlate with a Semantic Versioning identifier (\`MAJOR\`, \`MINOR\`, or \`PATCH\`) with the same or higher precedence than its associated commits`,
         linenumber: 1,
         column: 1,
       })

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -37,6 +37,10 @@ export function validatePullRequest(pullrequest: Commit, commits: ConventionalCo
 
   const pullRequestValue = orderValue(result);
   const validConventionalCommits = commits.filter(commit => commit.isValid);
+  // No valid commits found, return the pull request validation result
+  if (validConventionalCommits.length === 0) return result;
+
+  // Sort the commits by order of precedence (SemVer) and validate against the Pull Request (SemVer)
   const commitsValue = orderValue(validConventionalCommits.sort((a, b) => (orderValue(a) < orderValue(b) ? 1 : -1))[0]);
 
   if (pullRequestValue < commitsValue) {

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+
+import { Configuration } from "../src/configuration";
+import { FileSource, GitHubSource, GitSource } from "../src/datasources";
+
+jest.mock("../src/datasources");
+
+describe("FileSource", () => {
+  test("No Configuration file", async () => {
+    const config = new Configuration();
+    await config.fromDatasource(new FileSource(""));
+
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(false);
+    expect(config.updatePullRequestLabels).toBe(false);
+    expect(config.scopes).toStrictEqual([]);
+    expect(config.types).toStrictEqual([]);
+  });
+
+  test("Configuration file", async () => {
+    const config = new Configuration();
+
+    const datasource = new FileSource("");
+    // Mock the getConfigurationFile method
+    datasource.getConfigurationFile = jest.fn().mockResolvedValue(`{
+      "includeCommits": false,
+      "includePullRequest": true,
+      "updatePullRequestLabels": true,
+      "scopes": ["test-scope"],
+      "types": ["test-type"]
+    }`);
+    await config.fromDatasource(datasource, "configuration.json");
+
+    // These will be ignored as they only apply for GitHub Actions
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(false);
+    expect(config.updatePullRequestLabels).toBe(false);
+
+    // These will be set
+    expect(config.scopes).toStrictEqual(["test-scope"]);
+    expect(config.types).toStrictEqual(["test-type"]);
+  });
+});
+
+describe("GitSource", () => {
+  test("No Configuration file", async () => {
+    const config = new Configuration();
+    await config.fromDatasource(new GitSource());
+
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(false);
+    expect(config.updatePullRequestLabels).toBe(false);
+    expect(config.scopes).toStrictEqual([]);
+    expect(config.types).toStrictEqual([]);
+  });
+
+  test("Configuration file", async () => {
+    const config = new Configuration();
+
+    const datasource = new GitSource();
+    // Mock the getConfigurationFile method
+    datasource.getConfigurationFile = jest.fn().mockResolvedValue(`{
+      "githubAction": {
+        "includeCommits": false,
+        "includePullRequest": true,
+        "updatePullRequestLabels": true
+      },
+      "scopes": ["test-scope"],
+      "types": ["test-type"]
+    }`);
+    await config.fromDatasource(datasource, "configuration.json");
+
+    // These will be ignored as they only apply for GitHub Actions
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(false);
+    expect(config.updatePullRequestLabels).toBe(false);
+
+    // These will be set
+    expect(config.scopes).toStrictEqual(["test-scope"]);
+    expect(config.types).toStrictEqual(["test-type"]);
+  });
+});
+
+describe("GitHubSource", () => {
+  test("Auto Detect: No merge strategy configuration", async () => {
+    // Disable the GitHub Action inputs
+    jest.spyOn(core, "getInput").mockReturnValue("");
+    jest.spyOn(core, "getBooleanInput").mockReturnValue(false);
+
+    // Set the payload
+    github.context.payload.pull_request = { number: 1, base: { repo: {} } };
+
+    const config = new Configuration();
+    await expect(config.fromDatasource(new GitHubSource())).rejects.toThrow();
+  });
+
+  test("Auto Detect: allow rebase merge", async () => {
+    // Disable the GitHub Action inputs
+    jest.spyOn(core, "getInput").mockReturnValue("");
+    jest.spyOn(core, "getBooleanInput").mockReturnValue(false);
+
+    // Set the payload
+    github.context.payload.pull_request = {
+      number: 1,
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: true } },
+    };
+
+    const config = new Configuration();
+    await config.fromDatasource(new GitHubSource());
+
+    expect(config.includeCommits).toBe(true);
+  });
+
+  test("Auto Detect: disallow rebase merge", async () => {
+    // Disable the GitHub Action inputs
+    jest.spyOn(core, "getInput").mockReturnValue("");
+    jest.spyOn(core, "getBooleanInput").mockReturnValue(false);
+
+    // Set the payload
+    github.context.payload.pull_request = {
+      number: 1,
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+    };
+
+    const config = new Configuration();
+    await config.fromDatasource(new GitHubSource());
+
+    expect(config.includeCommits).toBe(false);
+  });
+
+  test("Configuration file only", async () => {
+    // Disable the GitHub Action inputs
+    jest.spyOn(core, "getInput").mockReturnValue("");
+    jest.spyOn(core, "getBooleanInput").mockReturnValue(false);
+
+    const datasource = new GitHubSource();
+    datasource.getConfigurationFile = jest.fn().mockResolvedValue(`{
+      "githubAction": {
+        "includeCommits": true,
+        "includePullRequest": true,
+        "updatePullRequestLabels": true
+      },
+      "scopes": ["test-scope"],
+      "types": ["test-type"]
+    }`);
+
+    // Set the payload
+    github.context.payload.pull_request = {
+      number: 1,
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+    };
+
+    const config = new Configuration();
+    await config.fromDatasource(datasource, "configuration.json");
+
+    // GitHub Actions configuration items
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(true);
+    expect(config.updatePullRequestLabels).toBe(true);
+
+    // Generic configuration items
+    expect(config.scopes).toStrictEqual(["test-scope"]);
+    expect(config.types).toStrictEqual(["test-type"]);
+  });
+
+  test("Inputs only", async () => {
+    jest.spyOn(core, "getInput").mockImplementation((name: string) => {
+      if (name === "include-commits") return "true";
+      if (name === "update-labels") return "true";
+      return "";
+    });
+
+    jest.spyOn(core, "getBooleanInput").mockImplementation((name: string) => {
+      if (name === "include-commits") return true;
+      if (name === "update-labels") return true;
+      return false;
+    });
+
+    jest.spyOn(core, "getMultilineInput").mockImplementation((name: string) => {
+      if (name === "scopes") return ["test-scope"];
+      if (name === "types") return ["test-type"];
+      return [];
+    });
+
+    // Set the payload
+    github.context.payload.pull_request = {
+      number: 1,
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+    };
+
+    const config = new Configuration();
+    await config.fromDatasource(new GitHubSource());
+
+    // GitHub Actions configuration items
+    expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(true);
+    expect(config.updatePullRequestLabels).toBe(true);
+
+    // Generic configuration items
+    expect(config.scopes).toStrictEqual(["test-scope"]);
+    expect(config.types).toStrictEqual(["test-type"]);
+  });
+
+  test("Inputs and Configuration", async () => {
+    jest.spyOn(core, "getInput").mockImplementation((name: string) => {
+      if (name === "include-commits") return "false";
+      if (name === "update-labels") return "false";
+      return "";
+    });
+
+    jest.spyOn(core, "getBooleanInput").mockImplementation((name: string) => {
+      if (name === "include-commits") return false;
+      if (name === "update-labels") return false;
+      return false;
+    });
+
+    jest.spyOn(core, "getMultilineInput").mockImplementation((name: string) => {
+      if (name === "scopes") return ["test-scope"];
+      if (name === "types") return ["test-type"];
+      return [];
+    });
+
+    const datasource = new GitHubSource();
+    datasource.getConfigurationFile = jest.fn().mockResolvedValue(`{
+      "githubAction": {
+        "includeCommits": true,
+        "includePullRequest": true,
+        "updatePullRequestLabels": true
+      },
+      "scopes": ["wrong-scope"],
+      "types": ["wrong-type"]
+    }`);
+
+    // Set the payload
+    github.context.payload.pull_request = {
+      number: 1,
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+    };
+
+    const config = new Configuration();
+    await config.fromDatasource(datasource);
+
+    // GitHub Actions configuration items
+    expect(config.includeCommits).toBe(false);
+    expect(config.includePullRequest).toBe(true);
+    expect(config.updatePullRequestLabels).toBe(false);
+
+    // Generic configuration items
+    expect(config.scopes).toStrictEqual(["test-scope"]);
+    expect(config.types).toStrictEqual(["test-type"]);
+  });
+});


### PR DESCRIPTION
# Changes included in this PR:

### Extend configuration management

Reworks the configuration management for the different
options of CommitMe (GitHub Action, CLI and PreCommit), incl:

- Extending the Configuration file with `githubActions` settings
- Ensure that the GitHub Actions inputs take precedence over the
  configuration file

In addition, this resolves several issue related to the configuration
as applied during the GHA execution.

### Stripping comments from parsed commit messages
Updates `commit-it` to v2.0.4 which ensures that we
manage our commit messages equal to `git` (stripping any comment
line)

### Prevent failure when validating non-compliant associated commits
Prevent the error...
```
Cannot read properties of undefined (reading 'breaking')
```
...when validating both the Pull Request and its associated commits,
where the associated commits are all non-compliant with Conventional
Commits.