### PR TITLE
fix: ignore both fixup! and merge commits

### DIFF
--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -2190,6 +2190,12 @@ class Commit {
     get raw() {
         return this._commit.raw;
     }
+    get isFixupCommit() {
+        return this._commit.attributes.isFixup;
+    }
+    get isMergeCommit() {
+        return this._commit.attributes.isMerge;
+    }
     toJSON() {
         return this._commit;
     }
@@ -2238,6 +2244,22 @@ function getFooterElementsFromParagraph(footer) {
 }
 exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
+ * Checks if the provided subject is a common (default) merge pattern.
+ * Currently supported:
+ * - GitHub
+ * - BitBucket
+ * - GitLab
+ *
+ * @param subject The subject to check
+ * @returns True if the subject is a common merge pattern, false otherwise
+ */
+function subjectIsMergePattern(subject) {
+    const githubMergeRegex = /^Merge pull request #(\d+) from '?(.*)'?$/;
+    const bitbucketMergeRegex = /^Merged in '?(.*)'? \(pull request #(\d+)\)$/;
+    const gitlabMergeRegex = /^Merge branch '?(.*?)'? into '?(.*?)'?$/;
+    return githubMergeRegex.test(subject) || bitbucketMergeRegex.test(subject) || gitlabMergeRegex.test(subject);
+}
+/**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
  * @param message The commit message
@@ -2261,13 +2283,20 @@ function parseCommitMessage(message) {
         if (body === "")
             body = undefined;
     }
+    const subject = paragraphs[0].trim();
+    const isFixup = subject.toLowerCase().startsWith("fixup!");
+    const isMerge = subjectIsMergePattern(subject);
     return {
-        subject: paragraphs[0].trim(),
-        body: body,
+        subject,
+        body,
         footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
             acc[cur.key] = cur.value;
             return acc;
         }, {}),
+        attributes: {
+            isFixup,
+            isMerge,
+        },
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
@@ -2405,6 +2434,13 @@ class ConventionalCommit {
         return (this._raw.breaking.value?.trimEnd() === "!" ||
             (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
     }
+    // Attributes
+    get isFixupCommit() {
+        return this._raw.commit.isFixupCommit;
+    }
+    get isMergeCommit() {
+        return this._raw.commit.isMergeCommit;
+    }
     // Raw
     get raw() {
         return this._raw.commit.raw;
@@ -2434,6 +2470,10 @@ class ConventionalCommit {
                 isValid: this.isValid,
                 errors: this.errors,
                 warnings: this.warnings,
+            },
+            attributes: {
+                isFixup: this.isFixupCommit,
+                isMerge: this.isMergeCommit,
             },
         };
     }
@@ -2564,13 +2604,7 @@ function parseCommitMessage(commit, hash) {
         .splice(1)
         .join("\n")
         .trim();
-    return {
-        raw,
-        hash: hash,
-        author: author,
-        committer: committer,
-        ...ccommit.parseCommitMessage(raw),
-    };
+    return { raw, hash, author, committer, ...ccommit.parseCommitMessage(raw) };
 }
 /**
  * Reads a (local) commit message from the .git/objects folder
@@ -41751,7 +41785,7 @@ exports.validatePullRequest = validatePullRequest;
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
 function validateCommits(commits) {
-    return commits.filter(commit => !commit.subject.startsWith("fixup!")).map(commit => validateCommit(commit));
+    return commits.filter(commit => !commit.isFixupCommit && !commit.isMergeCommit).map(commit => validateCommit(commit));
 }
 exports.validateCommits = validateCommits;
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2191,6 +2191,12 @@ class Commit {
     get raw() {
         return this._commit.raw;
     }
+    get isFixupCommit() {
+        return this._commit.attributes.isFixup;
+    }
+    get isMergeCommit() {
+        return this._commit.attributes.isMerge;
+    }
     toJSON() {
         return this._commit;
     }
@@ -2239,6 +2245,22 @@ function getFooterElementsFromParagraph(footer) {
 }
 exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
+ * Checks if the provided subject is a common (default) merge pattern.
+ * Currently supported:
+ * - GitHub
+ * - BitBucket
+ * - GitLab
+ *
+ * @param subject The subject to check
+ * @returns True if the subject is a common merge pattern, false otherwise
+ */
+function subjectIsMergePattern(subject) {
+    const githubMergeRegex = /^Merge pull request #(\d+) from '?(.*)'?$/;
+    const bitbucketMergeRegex = /^Merged in '?(.*)'? \(pull request #(\d+)\)$/;
+    const gitlabMergeRegex = /^Merge branch '?(.*?)'? into '?(.*?)'?$/;
+    return githubMergeRegex.test(subject) || bitbucketMergeRegex.test(subject) || gitlabMergeRegex.test(subject);
+}
+/**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
  * @param message The commit message
@@ -2262,13 +2284,20 @@ function parseCommitMessage(message) {
         if (body === "")
             body = undefined;
     }
+    const subject = paragraphs[0].trim();
+    const isFixup = subject.toLowerCase().startsWith("fixup!");
+    const isMerge = subjectIsMergePattern(subject);
     return {
-        subject: paragraphs[0].trim(),
-        body: body,
+        subject,
+        body,
         footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
             acc[cur.key] = cur.value;
             return acc;
         }, {}),
+        attributes: {
+            isFixup,
+            isMerge,
+        },
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
@@ -2406,6 +2435,13 @@ class ConventionalCommit {
         return (this._raw.breaking.value?.trimEnd() === "!" ||
             (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
     }
+    // Attributes
+    get isFixupCommit() {
+        return this._raw.commit.isFixupCommit;
+    }
+    get isMergeCommit() {
+        return this._raw.commit.isMergeCommit;
+    }
     // Raw
     get raw() {
         return this._raw.commit.raw;
@@ -2435,6 +2471,10 @@ class ConventionalCommit {
                 isValid: this.isValid,
                 errors: this.errors,
                 warnings: this.warnings,
+            },
+            attributes: {
+                isFixup: this.isFixupCommit,
+                isMerge: this.isMergeCommit,
             },
         };
     }
@@ -2565,13 +2605,7 @@ function parseCommitMessage(commit, hash) {
         .splice(1)
         .join("\n")
         .trim();
-    return {
-        raw,
-        hash: hash,
-        author: author,
-        committer: committer,
-        ...ccommit.parseCommitMessage(raw),
-    };
+    return { raw, hash, author, committer, ...ccommit.parseCommitMessage(raw) };
 }
 /**
  * Reads a (local) commit message from the .git/objects folder
@@ -41586,7 +41620,7 @@ exports.validatePullRequest = validatePullRequest;
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
 function validateCommits(commits) {
-    return commits.filter(commit => !commit.subject.startsWith("fixup!")).map(commit => validateCommit(commit));
+    return commits.filter(commit => !commit.isFixupCommit && !commit.isMergeCommit).map(commit => validateCommit(commit));
 }
 exports.validateCommits = validateCommits;
 

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -2191,6 +2191,12 @@ class Commit {
     get raw() {
         return this._commit.raw;
     }
+    get isFixupCommit() {
+        return this._commit.attributes.isFixup;
+    }
+    get isMergeCommit() {
+        return this._commit.attributes.isMerge;
+    }
     toJSON() {
         return this._commit;
     }
@@ -2239,6 +2245,22 @@ function getFooterElementsFromParagraph(footer) {
 }
 exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
+ * Checks if the provided subject is a common (default) merge pattern.
+ * Currently supported:
+ * - GitHub
+ * - BitBucket
+ * - GitLab
+ *
+ * @param subject The subject to check
+ * @returns True if the subject is a common merge pattern, false otherwise
+ */
+function subjectIsMergePattern(subject) {
+    const githubMergeRegex = /^Merge pull request #(\d+) from '?(.*)'?$/;
+    const bitbucketMergeRegex = /^Merged in '?(.*)'? \(pull request #(\d+)\)$/;
+    const gitlabMergeRegex = /^Merge branch '?(.*?)'? into '?(.*?)'?$/;
+    return githubMergeRegex.test(subject) || bitbucketMergeRegex.test(subject) || gitlabMergeRegex.test(subject);
+}
+/**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
  * @param message The commit message
@@ -2262,13 +2284,20 @@ function parseCommitMessage(message) {
         if (body === "")
             body = undefined;
     }
+    const subject = paragraphs[0].trim();
+    const isFixup = subject.toLowerCase().startsWith("fixup!");
+    const isMerge = subjectIsMergePattern(subject);
     return {
-        subject: paragraphs[0].trim(),
-        body: body,
+        subject,
+        body,
         footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
             acc[cur.key] = cur.value;
             return acc;
         }, {}),
+        attributes: {
+            isFixup,
+            isMerge,
+        },
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
@@ -2406,6 +2435,13 @@ class ConventionalCommit {
         return (this._raw.breaking.value?.trimEnd() === "!" ||
             (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
     }
+    // Attributes
+    get isFixupCommit() {
+        return this._raw.commit.isFixupCommit;
+    }
+    get isMergeCommit() {
+        return this._raw.commit.isMergeCommit;
+    }
     // Raw
     get raw() {
         return this._raw.commit.raw;
@@ -2435,6 +2471,10 @@ class ConventionalCommit {
                 isValid: this.isValid,
                 errors: this.errors,
                 warnings: this.warnings,
+            },
+            attributes: {
+                isFixup: this.isFixupCommit,
+                isMerge: this.isMergeCommit,
             },
         };
     }
@@ -2565,13 +2605,7 @@ function parseCommitMessage(commit, hash) {
         .splice(1)
         .join("\n")
         .trim();
-    return {
-        raw,
-        hash: hash,
-        author: author,
-        committer: committer,
-        ...ccommit.parseCommitMessage(raw),
-    };
+    return { raw, hash, author, committer, ...ccommit.parseCommitMessage(raw) };
 }
 /**
  * Reads a (local) commit message from the .git/objects folder
@@ -41569,7 +41603,7 @@ exports.validatePullRequest = validatePullRequest;
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
 function validateCommits(commits) {
-    return commits.filter(commit => !commit.subject.startsWith("fixup!")).map(commit => validateCommit(commit));
+    return commits.filter(commit => !commit.isFixupCommit && !commit.isMergeCommit).map(commit => validateCommit(commit));
 }
 exports.validateCommits = validateCommits;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -743,9 +743,9 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.0.4.tgz",
-      "integrity": "sha512-yhAj8RH0c8w4VCGYbt77JnRxemb/uwQrC/LpHEs0euiCTooTZW8VTGXgsOH/KnJC0lHeSoIHNF/Axk2UPSnU9A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.1.0.tgz",
+      "integrity": "sha512-ivPexRuSLBOKhjnyxou0iGomsxj63mtLpReL437AKFOCWoCC2ruu76lSWShGdLSf4jjv8oxV9+YH5RJGbc4Vew==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"
@@ -2663,9 +2663,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.635",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.635.tgz",
-      "integrity": "sha512-iu/2D0zolKU3iDGXXxdOzNf72Jnokn+K1IN6Kk4iV6l1Tr2g/qy+mvmtfAiBwZe5S3aB5r92vp+zSZ69scYRrg==",
+      "version": "1.4.636",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.636.tgz",
+      "integrity": "sha512-NLE0GIy1OL9wRiKL20h9TkctBEYZuc99tquSS9MVdTahnuHputoETHeqDzgqGqyOY9NUH0g9wjfEuw5OD+wRcQ==",
       "dev": true
     },
     "node_modules/emittery": {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -65,5 +65,5 @@ export function validatePullRequest(pullrequest: Commit, commits: ConventionalCo
  * @see https://www.conventionalcommits.org/en/v1.0.0/
  */
 export function validateCommits(commits: Commit[]): ConventionalCommit[] {
-  return commits.filter(commit => !commit.subject.startsWith("fixup!")).map(commit => validateCommit(commit));
+  return commits.filter(commit => !commit.isFixupCommit && !commit.isMergeCommit).map(commit => validateCommit(commit));
 }

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -233,3 +233,23 @@ describe("Validate valid Pull Request vs Commits", () => {
     }
   });
 });
+
+describe("Ignore fixup and merge commits", () => {
+  const testData = [
+    "fixup! feat: add new feature",
+    "fixup! fixup! feat: add new feature",
+    "Merge pull request #123 from some-branch/feature/branch",
+    "Merge pull request #123 from 'some-branch/feature/branch'",
+    "Merged in ci/some-branch (pull request #123)",
+    "Merged in 'ci/some-branch' (pull request #123)",
+    "Merge branch 'ci/some-branch' into 'main'",
+    "Merge branch 'ci/some-branch' into main",
+    "Merge branch ci/some-branch into main",
+  ];
+
+  it.each(testData)("$test", test => {
+    const result = validator.validateCommits([Commit.fromString({ hash: "0a0b0c0d", message: test })]);
+
+    expect(result.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This commit updates the ignore patterns for both `fixup!` and merge commits. The latter supports the default commit message subjects as generated by GitHub, GitLab and BitBucket.