### PR TITLE
feat: add `include-pull-request` input parameter to the GHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Include commits associated with the Pull Request; by default we use the repository configuration settings to determine this value.'
     required: false
   
+  include-pull-request:
+    description: 'Include the Pull Request title and description; by default we use the repository configuration settings to determine this value.'
+    required: false
+
   scopes:
     description: 'Conventional Commits scopes allowed for this repository; be default we accept all scopes.'
     required: false

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -11,13 +11,44 @@ You can scan your [pull requests](#pull-request-scanning) for determining compli
 
 ## Validation strategies
 
-Currently there are two distinct [Conventional Commits] validation strategies implemented;
-- Validate the Pull Request and all associated commits _(default behavior)_.
-- **ONLY** validate the Pull Request.
+By default, `CommitMe` will attempt to attempt to _automatically detect_ the validation strategy based on you repository merge strategies;
+- Pull Requests will be validated in case `Allow rebase merging` is enabled
+- Commits associated with your Pull Request with be validated in case either `Allow squash merging` or `Allow rebase merging` is enabled.
 
-Selection of the strategy is based on either:
-- The allowed merge strategies in your repository (the `contents: write` permission needs to be set in order for this detection to work.)
-- Manually configuring the `include-commits` input parameter
+| Validation of / Merge Strategy           | Rebase Merge       | Squash Merge       | Merge Commit       |
+| ---------------------------------------- | ------------------ | ------------------ | ------------------ |
+| Pull Request                             | :x:                | :white_check_mark: | :white_check_mark: |
+| Commits associated with the Pull Request | :white_check_mark: | :x:                | :x:                |
+| Pull Request *and* associated commits    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+> [!WARNING]
+> The `contents: write` permission needs to be set in order for this automatic detection to work.
+
+Alternatively, you can *manually* specify the strategy by setting the associated [GitHub Action Inputs](#inputs) or [Global Configuration file parameters](./config.md#github-actions-settings).
+
+> [!NOTE]
+> We strongly recommend using the above table to configure your project.**
+
+### Allow squash merging
+
+In order for `CommitMe` to operate most effectively, we **recommend** configuring the "default commit message";
+
+| Value | Recommended | Comment |
+| ----- | ----------- | ------- |
+| `Default Message` | :x: | GitHub will create a commit message in your target branch which will **not** be compliant with [Conventional Commits]. |
+| `Pull request title` | :warning: | Although this provides support for parsing the [Conventional Commits]-subjects, it will not provide the ability to use the `BREAKING[-]CHANGE` footer elements |
+| `Pull request title and commit details` | :warning: | Although this provides support for parsing the [Conventional Commits]-subjects, it will not provide the ability to use the `BREAKING[-]CHANGE` footer elements |
+| `Pull request title and description` | :white_check_mark: | Provides full [Conventional Commit] support on the Pull Request description and body, providing support for `BREAKING[-]CHANGE` footer elements in the Pull Request description. |
+
+### Allow merge commits
+
+In order for `CommitMe` to operate most effectively, we **recommend** configuring the "default commit message";
+
+| Value | Recommended | Comment |
+| ----- | ----------- | ------- |
+| `Default Message` | :x: | GitHub will create a commit message in your target branch which will **not** be compliant with [Conventional Commits]. |
+| `Pull request title` | :warning: | Although this provides support for parsing the [Conventional Commits]-subjects, it will not provide the ability to use the `BREAKING[-]CHANGE` footer elements |
+| `Pull request title and description` | :white_check_mark: | Provides full [Conventional Commit] support on the Pull Request description and body, providing support for `BREAKING[-]CHANGE` footer elements in the Pull Request description. |
 
 ## Workflows
 
@@ -133,10 +164,11 @@ In addition, we recommend the following activity types:
 | `scopes` | *NO* | Conventional Commit scopes to allow. No restrictions will be applied when not specified. |
 | `types` | *NO* | Conventional Commit types to allow. By default it always supports `feat` and `fix`. |
 | `include-commits` | *NO* | Include commits associated with the Pull Request during validation; by default we use the repository configuration settings to determine this value (requires `contents:write` permission if **NOT** set). |
+| `include-pull-request` | *NO* | Include the Pull Request title and description; by default we use the repository configuration settings to determine this value. |
 | `config` | *NO* | Path to the configuration file; by default `.pre-commit.json` is used. |
 
 > [!NOTE]
-> You can also configure the majority of the inputs using the [Global Configuration file](./config.md#github-actions-settings)
+> We recommend to configure `CommitMe` using the [Global Configuration file](./config.md#github-actions-settings)
 
 ### Permissions
 

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -41245,8 +41245,10 @@ class Configuration {
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
             const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasIncludePullRequestInput = core.getInput("include-pull-request") !== "";
             const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
             const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            const autoDetectIncludePR = !hasIncludePullRequestInput && config.githubAction?.includePullRequest === undefined;
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
@@ -41257,7 +41259,15 @@ class Configuration {
                     ? core.getBooleanInput("include-commits")
                     : config.githubAction?.includeCommits ?? false;
             }
-            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (autoDetectIncludePR) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                this.includePullRequest = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includePullRequest = hasIncludePullRequestInput
+                    ? core.getBooleanInput("include-pull-request")
+                    : config.githubAction?.includePullRequest ?? true;
+            }
             if (core.getMultilineInput("scopes").length > 0) {
                 this.addScopes(core.getMultilineInput("scopes"));
             }

--- a/lib/action/index.js
+++ b/lib/action/index.js
@@ -41252,7 +41252,9 @@ class Configuration {
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
-                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+                this.includeCommits =
+                    github.context.payload.pull_request.base.repo.allow_rebase_merge === true ||
+                        github.context.payload.pull_request.base.repo.allow_squash_merge === true;
             }
             else {
                 this.includeCommits = hasIncludeCommitsInput

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41246,8 +41246,10 @@ class Configuration {
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
             const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasIncludePullRequestInput = core.getInput("include-pull-request") !== "";
             const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
             const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            const autoDetectIncludePR = !hasIncludePullRequestInput && config.githubAction?.includePullRequest === undefined;
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
@@ -41258,7 +41260,15 @@ class Configuration {
                     ? core.getBooleanInput("include-commits")
                     : config.githubAction?.includeCommits ?? false;
             }
-            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (autoDetectIncludePR) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                this.includePullRequest = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includePullRequest = hasIncludePullRequestInput
+                    ? core.getBooleanInput("include-pull-request")
+                    : config.githubAction?.includePullRequest ?? true;
+            }
             if (core.getMultilineInput("scopes").length > 0) {
                 this.addScopes(core.getMultilineInput("scopes"));
             }

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -41253,7 +41253,9 @@ class Configuration {
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
-                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+                this.includeCommits =
+                    github.context.payload.pull_request.base.repo.allow_rebase_merge === true ||
+                        github.context.payload.pull_request.base.repo.allow_squash_merge === true;
             }
             else {
                 this.includeCommits = hasIncludeCommitsInput

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -41246,8 +41246,10 @@ class Configuration {
         }
         else if (datasource instanceof datasources_1.GitHubSource) {
             const hasIncludeCommitsInput = core.getInput("include-commits") !== "";
+            const hasIncludePullRequestInput = core.getInput("include-pull-request") !== "";
             const hasPullRequestLabelsInput = core.getInput("update-labels") !== "";
             const autoDetectIncludeCommits = !hasIncludeCommitsInput && config.githubAction?.includeCommits === undefined;
+            const autoDetectIncludePR = !hasIncludePullRequestInput && config.githubAction?.includePullRequest === undefined;
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
@@ -41258,7 +41260,15 @@ class Configuration {
                     ? core.getBooleanInput("include-commits")
                     : config.githubAction?.includeCommits ?? false;
             }
-            this.includePullRequest = config.githubAction?.includePullRequest ?? true;
+            if (autoDetectIncludePR) {
+                (0, assert_1.default)(github.context.payload.pull_request);
+                this.includePullRequest = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+            }
+            else {
+                this.includePullRequest = hasIncludePullRequestInput
+                    ? core.getBooleanInput("include-pull-request")
+                    : config.githubAction?.includePullRequest ?? true;
+            }
             if (core.getMultilineInput("scopes").length > 0) {
                 this.addScopes(core.getMultilineInput("scopes"));
             }

--- a/lib/precommit/index.js
+++ b/lib/precommit/index.js
@@ -41253,7 +41253,9 @@ class Configuration {
             if (autoDetectIncludeCommits) {
                 (0, assert_1.default)(github.context.payload.pull_request);
                 repository.checkConfiguration(github.context.payload.pull_request.base.repo);
-                this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+                this.includeCommits =
+                    github.context.payload.pull_request.base.repo.allow_rebase_merge === true ||
+                        github.context.payload.pull_request.base.repo.allow_squash_merge === true;
             }
             else {
                 this.includeCommits = hasIncludeCommitsInput

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -84,7 +84,9 @@ class Configuration implements IConventionalCommitOptions {
       if (autoDetectIncludeCommits) {
         assert(github.context.payload.pull_request);
         repository.checkConfiguration(github.context.payload.pull_request.base.repo);
-        this.includeCommits = github.context.payload.pull_request.base.repo.allow_rebase_merge === true;
+        this.includeCommits =
+          github.context.payload.pull_request.base.repo.allow_rebase_merge === true ||
+          github.context.payload.pull_request.base.repo.allow_squash_merge === true;
       } else {
         this.includeCommits = hasIncludeCommitsInput
           ? core.getBooleanInput("include-commits")

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -115,6 +115,7 @@ describe("GitHubSource", () => {
     await config.fromDatasource(new GitHubSource());
 
     expect(config.includeCommits).toBe(true);
+    expect(config.includePullRequest).toBe(true);
   });
 
   test("Auto Detect: disallow rebase merge", async () => {
@@ -132,6 +133,7 @@ describe("GitHubSource", () => {
     await config.fromDatasource(new GitHubSource());
 
     expect(config.includeCommits).toBe(false);
+    expect(config.includePullRequest).toBe(false);
   });
 
   test("Configuration file only", async () => {
@@ -172,12 +174,14 @@ describe("GitHubSource", () => {
   test("Inputs only", async () => {
     jest.spyOn(core, "getInput").mockImplementation((name: string) => {
       if (name === "include-commits") return "true";
+      if (name === "include-pull-request") return "true";
       if (name === "update-labels") return "true";
       return "";
     });
 
     jest.spyOn(core, "getBooleanInput").mockImplementation((name: string) => {
       if (name === "include-commits") return true;
+      if (name === "include-pull-request") return true;
       if (name === "update-labels") return true;
       return false;
     });
@@ -191,7 +195,7 @@ describe("GitHubSource", () => {
     // Set the payload
     github.context.payload.pull_request = {
       number: 1,
-      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+      base: { repo: { allow_merge_commit: false, allow_squash_merge: false, allow_rebase_merge: false } },
     };
 
     const config = new Configuration();
@@ -210,12 +214,14 @@ describe("GitHubSource", () => {
   test("Inputs and Configuration", async () => {
     jest.spyOn(core, "getInput").mockImplementation((name: string) => {
       if (name === "include-commits") return "false";
+      if (name === "include-pull-request") return "false";
       if (name === "update-labels") return "false";
       return "";
     });
 
     jest.spyOn(core, "getBooleanInput").mockImplementation((name: string) => {
       if (name === "include-commits") return false;
+      if (name === "include-pull-request") return false;
       if (name === "update-labels") return false;
       return false;
     });
@@ -240,7 +246,7 @@ describe("GitHubSource", () => {
     // Set the payload
     github.context.payload.pull_request = {
       number: 1,
-      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: false } },
+      base: { repo: { allow_merge_commit: true, allow_squash_merge: true, allow_rebase_merge: true } },
     };
 
     const config = new Configuration();
@@ -248,7 +254,7 @@ describe("GitHubSource", () => {
 
     // GitHub Actions configuration items
     expect(config.includeCommits).toBe(false);
-    expect(config.includePullRequest).toBe(true);
+    expect(config.includePullRequest).toBe(false);
     expect(config.updatePullRequestLabels).toBe(false);
 
     // Generic configuration items


### PR DESCRIPTION
This commit introduces the `include-pull-request` input parameter to `dev-build-deploy/commit-me`, incl:

- Ability to auto-detect the value based on the configured merge strategies (see updated documentation for details).
- Override the value from the GHA inputs

This ensures feature  parity between the configuration file and GHA.